### PR TITLE
Add confidence returns for market data and risk functions

### DIFF
--- a/examples/core/advanced_financial_modeling_demo.py
+++ b/examples/core/advanced_financial_modeling_demo.py
@@ -241,7 +241,7 @@ def demo_var_with_leverage():
     borrowed_amount = 60000
 
     # Calculate VaR
-    var_metrics = modeler.calculate_var_with_leverage(
+    var_metrics, conf = modeler.calculate_var_with_leverage(
         position_size=position_size,
         borrowed_amount=borrowed_amount,
         returns_distribution=returns,

--- a/src/unity_wheel/backtesting/wheel_backtester.py
+++ b/src/unity_wheel/backtesting/wheel_backtester.py
@@ -230,7 +230,7 @@ class WheelBacktester:
         # Risk metrics
         sharpe_ratio = self._calculate_sharpe(returns_series)
         max_drawdown = self._calculate_max_drawdown(equity_curve)
-        var_95, cvar_95 = self._calculate_var_cvar(returns_series)
+        var_95, cvar_95, _ = self._calculate_var_cvar(returns_series)
 
         # Trade statistics
         winning_trades = sum(1 for p in positions if p.realized_pnl > 0)
@@ -582,10 +582,10 @@ class WheelBacktester:
         self,
         returns: pd.Series,
         confidence: float = 0.95,
-    ) -> Tuple[float, float]:
-        """Calculate VaR and CVaR."""
+    ) -> Tuple[float, float, float]:
+        """Calculate VaR and CVaR with a confidence score."""
         if len(returns) < 20:
-            return 0.0, 0.0
+            return 0.0, 0.0, 0.3
 
         # Historical VaR
         var_percentile = (1 - confidence) * 100
@@ -594,7 +594,9 @@ class WheelBacktester:
         # CVaR (expected shortfall)
         cvar = returns[returns <= var].mean()
 
-        return var, cvar
+        conf = 1.0 if len(returns) >= 250 else 0.8
+
+        return var, cvar, conf
 
     def _calculate_max_gap_loss(
         self,

--- a/src/unity_wheel/cli/databento_integration.py
+++ b/src/unity_wheel/cli/databento_integration.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 async def create_databento_market_snapshot(
     portfolio_value: float,
     ticker: str = "U",
-) -> MarketSnapshot:
+) -> tuple[MarketSnapshot, float]:
     """Create market snapshot from real Databento data.
 
     Args:
@@ -124,14 +124,16 @@ async def create_databento_market_snapshot(
                 implied_volatility=0.45,  # Unity typical IV
                 risk_free_rate=0.05,
             )
+            # Confidence based on number of option candidates
+            confidence = 1.0 if len(option_chain) > 10 else 0.8
 
-            return market_snapshot
+            return market_snapshot, confidence
 
         finally:
             await client.close()
 
 
-def get_market_data_sync(portfolio_value: float, ticker: str = "U") -> MarketSnapshot:
+def get_market_data_sync(portfolio_value: float, ticker: str = "U") -> tuple[MarketSnapshot, float]:
     """Synchronous wrapper for getting market data.
 
     Args:

--- a/src/unity_wheel/cli/run.py
+++ b/src/unity_wheel/cli/run.py
@@ -101,8 +101,8 @@ def generate_recommendation(
 
     # Get real market data - fail if not available
     try:
-        market_snapshot = get_market_data_sync(portfolio_value, TICKER)
-        logger.info(f"Successfully fetched real Unity market data")
+        market_snapshot, confidence = get_market_data_sync(portfolio_value, TICKER)
+        logger.info("Successfully fetched real Unity market data", extra={"confidence": confidence})
         current_price = market_snapshot.current_price
 
         # CRITICAL: Validate this is real market data, not mock/dummy data

--- a/src/unity_wheel/monitoring/scripts/daily_health_check.py
+++ b/src/unity_wheel/monitoring/scripts/daily_health_check.py
@@ -116,8 +116,11 @@ async def test_decision_engine() -> dict:
             from src.unity_wheel.data_providers.databento import DatabentoClient
 
             # Get real market data
-            market_data = get_market_data_sync(100000, config.unity.ticker)
-            logger.info(f"Decision engine check using real {config.unity.ticker} data")
+            market_data, confidence = get_market_data_sync(100000, config.unity.ticker)
+            logger.info(
+                f"Decision engine check using real {config.unity.ticker} data",
+                extra={"confidence": confidence},
+            )
             results["issues"].append("Decision engine initialized with real market data")
 
         except Exception as e:

--- a/src/unity_wheel/risk/advanced_financial_modeling.py
+++ b/src/unity_wheel/risk/advanced_financial_modeling.py
@@ -221,7 +221,7 @@ class AdvancedFinancialModeling:
         total_capital: float,
         risk_free_rate: float = 0.05,
         benchmark_returns: Optional[np.ndarray] = None,
-    ) -> RiskAdjustedMetrics:
+    ) -> Tuple[RiskAdjustedMetrics, float]:
         """
         Calculate comprehensive risk-adjusted metrics.
 
@@ -307,7 +307,7 @@ class AdvancedFinancialModeling:
             else float("inf")
         )
 
-        return RiskAdjustedMetrics(
+        metrics = RiskAdjustedMetrics(
             sharpe_ratio=sharpe_ratio,
             sortino_ratio=sortino_ratio,
             calmar_ratio=calmar_ratio,
@@ -321,6 +321,10 @@ class AdvancedFinancialModeling:
             debt_to_equity=debt_to_equity,
             interest_coverage=interest_coverage,
         )
+
+        confidence = 1.0 if len(returns) >= 252 else 0.8
+
+        return metrics, confidence
 
     def optimize_capital_structure(
         self,
@@ -526,7 +530,7 @@ class AdvancedFinancialModeling:
         unity_returns: np.ndarray,
         interest_rates: np.ndarray,
         other_factors: Optional[Dict[str, np.ndarray]] = None,
-    ) -> Dict[str, float]:
+    ) -> Tuple[Dict[str, float], float]:
         """
         Analyze correlation between Unity returns and interest rates.
 
@@ -642,7 +646,7 @@ class AdvancedFinancialModeling:
         model_risk_multiplier = 1.2  # 20% model risk buffer
         worst_case_var = var_leveraged * model_risk_multiplier
 
-        return {
+        results = {
             "var_basic": var_basic,
             "var_leveraged": var_leveraged,
             "cvar_basic": cvar_basic,
@@ -655,3 +659,7 @@ class AdvancedFinancialModeling:
                 net_returns < -0.30
             ),  # 30% loss triggers margin call
         }
+
+        conf = 1.0 if len(returns_distribution) >= 250 else 0.8
+
+        return results, conf

--- a/tests/test_integrated_financial_modeling.py
+++ b/tests/test_integrated_financial_modeling.py
@@ -241,7 +241,7 @@ class TestAdvancedFinancialModeling:
         np.random.seed(42)
         returns = np.random.normal(0.001, 0.02, 252)
 
-        metrics = modeler.calculate_risk_adjusted_metrics(
+        metrics, conf = modeler.calculate_risk_adjusted_metrics(
             returns=returns,
             borrowed_capital=20000,
             total_capital=50000,
@@ -257,6 +257,7 @@ class TestAdvancedFinancialModeling:
         # Leverage ratio should be correct
         expected_leverage = 50000 / (50000 - 20000)
         assert abs(metrics.leverage_ratio - expected_leverage) < 0.01
+        assert 0 <= conf <= 1
 
     def test_optimal_capital_structure(self, modeler):
         """Test optimal leverage calculation."""
@@ -276,7 +277,7 @@ class TestAdvancedFinancialModeling:
         np.random.seed(42)
         returns = np.random.standard_t(df=5, size=1000) * 0.03
 
-        var_result = modeler.calculate_var_with_leverage(
+        var_result, conf = modeler.calculate_var_with_leverage(
             position_size=100000,
             borrowed_amount=60000,
             returns_distribution=returns,
@@ -288,6 +289,7 @@ class TestAdvancedFinancialModeling:
         assert "var_leveraged" in var_result
         assert "cvar_basic" in var_result
         assert "cvar_leveraged" in var_result
+        assert 0 <= conf <= 1
 
         # Leveraged VaR should be higher
         assert var_result["var_leveraged"] > var_result["var_basic"]

--- a/tests/test_wheel_backtester.py
+++ b/tests/test_wheel_backtester.py
@@ -251,12 +251,13 @@ class TestWheelBacktester:
         # Create returns series
         returns = pd.Series(np.random.normal(-0.001, 0.02, 100))  # Slight negative drift
 
-        var_95, cvar_95 = backtester._calculate_var_cvar(returns)
+        var_95, cvar_95, conf = backtester._calculate_var_cvar(returns)
 
         # VaR should be negative (loss)
         assert var_95 < 0
         # CVaR should be worse than VaR
         assert cvar_95 < var_95
+        assert 0 <= conf <= 1
 
     def test_max_drawdown_calculation(self, backtester):
         """Test maximum drawdown calculation."""


### PR DESCRIPTION
## Summary
- include confidence score when building Databento market snapshots
- propagate confidence from `get_market_data_sync`
- add confidence output from risk analytics (`calculate_var_with_leverage`, `calculate_risk_adjusted_metrics`)
- expose confidence in backtester VaR calculations
- update tests for new return values

## Testing
- `ruff format . && black .`
- `ruff check --fix .`
- `mypy --strict unity_trading data_pipeline ml_engine strategy_engine risk_engine app --ignore-missing-imports`
- `pytest -q tests/smoke`
- `pip-compile --dry-run` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68484ff2d5c88330b813822a82aec9fb