### PR TITLE
Unify Position model

### DIFF
--- a/src/unity_wheel/recommendations/__init__.py
+++ b/src/unity_wheel/recommendations/__init__.py
@@ -1,6 +1,7 @@
 """Wheel strategy recommendation system with autonomous operation."""
 
 from .engine import RecommendationEngine
-from .models import AccountState, Position, Recommendation
+from .models import AccountState, Recommendation
+from ..models.position import Position
 
 __all__ = ["RecommendationEngine", "Position", "AccountState", "Recommendation"]


### PR DESCRIPTION
## Summary
- clean up recommendations models
- re-export unified `Position` in recommendations API

## Testing
- `ruff format . && black .`
- `ruff check --fix .`
- `mypy --strict unity_trading data_pipeline ml_engine strategy_engine risk_engine app --ignore-missing-imports`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684852a7ebc883309ba53ae5437383e2