### PR TITLE
Implement seed control helper

### DIFF
--- a/src/unity_wheel/risk/advanced_financial_modeling.py
+++ b/src/unity_wheel/risk/advanced_financial_modeling.py
@@ -117,6 +117,7 @@ class AdvancedFinancialModeling:
             borrowed_amount: Amount borrowed
             n_simulations: Number of simulation paths
             include_path_dependency: Model path-dependent features
+            random_seed: Seed for deterministic simulation results
 
         Returns:
             MonteCarloResult with statistics

--- a/tests/test_wheel_backtester.py
+++ b/tests/test_wheel_backtester.py
@@ -10,6 +10,7 @@ import pytest
 from src.unity_wheel.backtesting import BacktestPosition, BacktestResults, WheelBacktester
 from src.unity_wheel.storage import Storage
 from src.unity_wheel.strategy.wheel import WheelParameters
+from src.unity_wheel.utils.random_utils import set_seed
 
 
 class TestWheelBacktester:
@@ -31,6 +32,7 @@ class TestWheelBacktester:
     @pytest.fixture
     def sample_price_data(self):
         """Create sample price data for testing."""
+        set_seed(42)
         dates = pd.date_range("2024-01-01", "2024-03-31", freq="D")
         prices = 35 + np.sin(np.arange(len(dates)) * 0.1) * 5  # Oscillating around $35
 


### PR DESCRIPTION
## Summary
- document optional `random_seed` argument in advanced financial modeling
- seed wheel backtester fixture for deterministic test data

## Testing
- `ruff check --select F,E,I tests/test_wheel_backtester.py src/unity_wheel/risk/advanced_financial_modeling.py`
- `pytest -q tests/test_wheel_backtester.py::TestWheelBacktester::test_simulate_assignment_itm` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684821e2ce5c833093344ab8ba6fa3a9