### PR TITLE
Remove unity_trading directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This project uses an automated housekeeping script to enforce file placement and
    ```bash
    ruff format . && black .
    ruff check --fix .
-   mypy --strict unity_trading data_pipeline ml_engine strategy_engine risk_engine app --ignore-missing-imports
+   mypy --strict src/unity_wheel data_pipeline ml_engine strategy_engine risk_engine app --ignore-missing-imports
    pytest -q
    ```
 4. Commit your changes once all checks pass.

--- a/clean_database.py
+++ b/clean_database.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Clean up database - remove empty tables and fix data issues."""
+
 import os
 
 import duckdb
@@ -27,7 +28,7 @@ for table in empty_tables:
         if count == 0:
             print(f"   Dropping empty table: {table}")
             conn.execute(f"DROP TABLE IF EXISTS {table}")
-    except:
+    except Exception:
         pass
 
 # Fix inverted spreads in options data

--- a/unity_trading/__init__.py
+++ b/unity_trading/__init__.py
@@ -1,1 +1,0 @@
-../src/unity_wheel/__init__.py

--- a/unity_trading/__version__.py
+++ b/unity_trading/__version__.py
@@ -1,1 +1,0 @@
-../src/unity_wheel/__version__.py

--- a/unity_trading/adaptive
+++ b/unity_trading/adaptive
@@ -1,1 +1,0 @@
-../src/unity_wheel/adaptive

--- a/unity_trading/analytics
+++ b/unity_trading/analytics
@@ -1,1 +1,0 @@
-../src/unity_wheel/analytics

--- a/unity_trading/api
+++ b/unity_trading/api
@@ -1,1 +1,0 @@
-../src/unity_wheel/api

--- a/unity_trading/auth
+++ b/unity_trading/auth
@@ -1,1 +1,0 @@
-../src/unity_wheel/auth

--- a/unity_trading/backtesting
+++ b/unity_trading/backtesting
@@ -1,1 +1,0 @@
-../src/unity_wheel/backtesting

--- a/unity_trading/cli
+++ b/unity_trading/cli
@@ -1,1 +1,0 @@
-../src/unity_wheel/cli

--- a/unity_trading/data_providers
+++ b/unity_trading/data_providers
@@ -1,1 +1,0 @@
-../src/unity_wheel/data_providers

--- a/unity_trading/execution
+++ b/unity_trading/execution
@@ -1,1 +1,0 @@
-../src/unity_wheel/execution

--- a/unity_trading/math
+++ b/unity_trading/math
@@ -1,1 +1,0 @@
-../src/unity_wheel/math

--- a/unity_trading/metrics
+++ b/unity_trading/metrics
@@ -1,1 +1,0 @@
-../src/unity_wheel/metrics

--- a/unity_trading/models
+++ b/unity_trading/models
@@ -1,1 +1,0 @@
-../src/unity_wheel/models

--- a/unity_trading/monitoring
+++ b/unity_trading/monitoring
@@ -1,1 +1,0 @@
-../src/unity_wheel/monitoring

--- a/unity_trading/observability
+++ b/unity_trading/observability
@@ -1,1 +1,0 @@
-../src/unity_wheel/observability

--- a/unity_trading/portfolio
+++ b/unity_trading/portfolio
@@ -1,1 +1,0 @@
-../src/unity_wheel/portfolio

--- a/unity_trading/recommendations
+++ b/unity_trading/recommendations
@@ -1,1 +1,0 @@
-../src/unity_wheel/recommendations

--- a/unity_trading/risk
+++ b/unity_trading/risk
@@ -1,1 +1,0 @@
-../src/unity_wheel/risk

--- a/unity_trading/schwab
+++ b/unity_trading/schwab
@@ -1,1 +1,0 @@
-../src/unity_wheel/schwab

--- a/unity_trading/secrets
+++ b/unity_trading/secrets
@@ -1,1 +1,0 @@
-../src/unity_wheel/secrets

--- a/unity_trading/storage
+++ b/unity_trading/storage
@@ -1,1 +1,0 @@
-../src/unity_wheel/storage

--- a/unity_trading/strategy
+++ b/unity_trading/strategy
@@ -1,1 +1,0 @@
-../src/unity_wheel/strategy

--- a/unity_trading/utils
+++ b/unity_trading/utils
@@ -1,1 +1,0 @@
-../src/unity_wheel/utils


### PR DESCRIPTION
## Summary
- delete `unity_trading/` duplicate package
- update docs to reference `src/unity_wheel`
- fix a Ruff error in `clean_database.py`

## Testing
- `ruff format . && black .`
- `ruff check --fix .`
- `mypy --strict src/unity_wheel data_pipeline ml_engine strategy_engine risk_engine app --ignore-missing-imports` *(fails: 959 errors)*
- `pytest -q` *(fails to run: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68485e1248c4833080a7ef0ac08e3c63