### PR TITLE
Refactor ticker refs to config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,18 @@
 # pytest_plugins = ["app.pytest_cov"]  # Commented out to avoid conflict with pytest-cov
+
+import os
+import pathlib
+
+import pytest
+
+from src.config.loader import get_config_loader
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _load_test_config(monkeypatch) -> None:
+    """Ensure configuration is loaded for tests."""
+    config_path = pathlib.Path(__file__).resolve().parents[1] / "config.yaml"
+    monkeypatch.setenv("WHEEL_CONFIG_PATH", str(config_path))
+    # Force reload so each test session starts fresh
+    loader = get_config_loader(str(config_path))
+    loader.reload()

--- a/tests/test_dynamic_optimization.py
+++ b/tests/test_dynamic_optimization.py
@@ -8,6 +8,8 @@ import os
 import sys
 from datetime import datetime
 
+from src.config.loader import get_config
+
 import duckdb
 import numpy as np
 
@@ -20,6 +22,7 @@ from src.unity_wheel.analytics.dynamic_optimizer import (
 )
 
 DB_PATH = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
+TICKER = get_config().unity.ticker
 
 
 def calculate_market_state(returns: np.ndarray, prices: list) -> MarketState:
@@ -70,10 +73,10 @@ def main():
     # Load Unity data
     conn = duckdb.connect(DB_PATH)
     data = conn.execute(
-        """
+        f"""
         SELECT date, open, high, low, close, volume, returns
         FROM price_history
-        WHERE symbol = 'U' AND returns IS NOT NULL
+        WHERE symbol = '{TICKER}' AND returns IS NOT NULL
         ORDER BY date
     """
     ).fetchall()
@@ -91,7 +94,7 @@ def main():
     print(f"   20-day Momentum: {market_state.price_momentum:+.1%}")
 
     # Initialize optimizer
-    optimizer = DynamicOptimizer(symbol="U")
+    optimizer = DynamicOptimizer(symbol=TICKER)
 
     # Run optimization
     print(f"\n🔧 Running Dynamic Optimization...")

--- a/tests/test_integrated_system.py
+++ b/tests/test_integrated_system.py
@@ -9,6 +9,8 @@ import os
 import sys
 from datetime import datetime, timedelta
 
+from src.config.loader import get_config
+
 import duckdb
 import numpy as np
 import pandas as pd
@@ -18,6 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from src.unity_wheel.analytics import EventType, IntegratedDecisionEngine
 
 DB_PATH = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
+TICKER = get_config().unity.ticker
 
 
 def load_unity_data():
@@ -25,10 +28,10 @@ def load_unity_data():
     conn = duckdb.connect(DB_PATH)
 
     data = conn.execute(
-        """
+        f"""
         SELECT date, open, high, low, close, volume, returns
         FROM price_history
-        WHERE symbol = 'U'
+        WHERE symbol = '{TICKER}'
         ORDER BY date
     """
     ).fetchall()
@@ -262,7 +265,7 @@ async def main():
     # Initialize decision engine
     print("\n🧠 Initializing Integrated Decision Engine...")
     engine = IntegratedDecisionEngine(
-        symbol="U", portfolio_value=100000, config={"max_contracts": 10, "min_confidence": 0.30}
+        symbol=TICKER, portfolio_value=100000, config={"max_contracts": 10, "min_confidence": 0.30}
     )
 
     # Fit anomaly detector on historical data

--- a/tests/test_market_calibration.py
+++ b/tests/test_market_calibration.py
@@ -9,6 +9,8 @@ import os
 import sys
 from datetime import datetime
 
+from src.config.loader import get_config
+
 import duckdb
 import numpy as np
 import pandas as pd
@@ -19,6 +21,7 @@ from src.unity_wheel.analytics.market_calibrator import MarketCalibrator
 from src.unity_wheel.risk.regime_detector import RegimeDetector
 
 DB_PATH = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
+TICKER = get_config().unity.ticker
 
 
 async def test_calibration():
@@ -32,10 +35,10 @@ async def test_calibration():
 
     # Load Unity data
     data = conn.execute(
-        """
+        f"""
         SELECT date, open, high, low, close, volume, returns
         FROM price_history
-        WHERE symbol = 'U'
+        WHERE symbol = '{TICKER}'
         ORDER BY date
     """
     ).fetchall()
@@ -52,7 +55,7 @@ async def test_calibration():
     print(f"   Date range: {dates[0]} to {dates[-1]}")
 
     # Initialize calibrator
-    calibrator = MarketCalibrator(symbol="U")
+    calibrator = MarketCalibrator(symbol=TICKER)
 
     # Calibrate parameters
     print("\n🔧 Calibrating optimal parameters...")

--- a/tests/test_regime_aware_risk.py
+++ b/tests/test_regime_aware_risk.py
@@ -8,6 +8,8 @@ import os
 import warnings
 from datetime import datetime, timedelta
 
+from src.config.loader import get_config
+
 import duckdb
 import numpy as np
 import pandas as pd
@@ -17,6 +19,7 @@ from sklearn.mixture import GaussianMixture
 warnings.filterwarnings("ignore")
 
 DB_PATH = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
+TICKER = get_config().unity.ticker
 
 
 class RegimeAwareRiskAnalyzer:
@@ -187,10 +190,10 @@ def main():
 
     # Get Unity returns
     returns_data = conn.execute(
-        """
+        f"""
         SELECT date, returns
         FROM price_history
-        WHERE symbol = 'U'
+        WHERE symbol = '{TICKER}'
         AND returns IS NOT NULL
         ORDER BY date
     """

--- a/tests/test_schwab_data_ingestion.py
+++ b/tests/test_schwab_data_ingestion.py
@@ -15,6 +15,8 @@ from decimal import Decimal
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from src.config.loader import get_config
+
 import pytest
 
 from src.unity_wheel.data_providers.schwab.ingestion import (
@@ -25,6 +27,8 @@ from src.unity_wheel.data_providers.schwab.ingestion import (
 )
 from src.unity_wheel.schwab.client import SchwabClient
 from src.unity_wheel.schwab.types import PositionType, SchwabAccount, SchwabPosition
+
+TICKER = get_config().unity.ticker
 
 
 class TestDataStorage:
@@ -43,7 +47,7 @@ class TestDataStorage:
         # Create test positions
         positions = [
             SchwabPosition(
-                symbol="U",
+                symbol=TICKER,
                 quantity=Decimal("100"),
                 position_type=PositionType.STOCK,
                 market_value=Decimal("5000"),
@@ -85,7 +89,7 @@ class TestDataStorage:
         for i in range(5):
             timestamp = datetime.now(timezone.utc) - timedelta(days=i)
             position = SchwabPosition(
-                symbol="U",
+                symbol=TICKER,
                 quantity=Decimal("100"),
                 position_type=PositionType.STOCK,
                 market_value=Decimal(f"{5000 - i * 100}"),
@@ -206,7 +210,7 @@ class TestDataIngestion:
         # Mock responses
         mock_positions = [
             SchwabPosition(
-                symbol="U",
+                symbol=TICKER,
                 quantity=Decimal("100"),
                 position_type=PositionType.STOCK,
                 market_value=Decimal("5000"),
@@ -356,7 +360,7 @@ class TestDataSanityChecks:
         positions = [
             # Normal position
             SchwabPosition(
-                symbol="U",
+                symbol=TICKER,
                 quantity=Decimal("100"),
                 position_type=PositionType.STOCK,
                 market_value=Decimal("5000"),
@@ -474,7 +478,7 @@ class TestDataSanityChecks:
         positions = [
             # Odd lot - potential stock split
             SchwabPosition(
-                symbol="U",
+                symbol=TICKER,
                 quantity=Decimal("150"),  # Not a round lot
                 position_type=PositionType.STOCK,
                 market_value=Decimal("7500"),
@@ -555,7 +559,7 @@ async def test_full_data_pipeline():
         # Mock comprehensive data
         mock_client.get_positions.return_value = [
             SchwabPosition(
-                symbol="U",
+                symbol=TICKER,
                 quantity=Decimal("200"),
                 position_type=PositionType.STOCK,
                 market_value=Decimal("10000"),

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import pytest
+from src.config.loader import get_config
 
 from src.unity_wheel.models.position import Position
 from src.unity_wheel.strategy.wheel import WheelStrategy
+
+TICKER = get_config().unity.ticker
 
 
 class TestWheelStrategy:
@@ -73,7 +76,7 @@ class TestWheelStrategy:
         """Test position sizing calculation."""
         # With 20% max allocation and $100k portfolio
         size = wheel.calculate_position_size(
-            symbol="U",
+            symbol=TICKER,
             current_price=35,
             portfolio_value=100000,
         )
@@ -83,7 +86,7 @@ class TestWheelStrategy:
 
         # Test with larger portfolio
         size = wheel.calculate_position_size(
-            symbol="U",
+            symbol=TICKER,
             current_price=35,
             portfolio_value=1000000,
         )
@@ -93,7 +96,7 @@ class TestWheelStrategy:
     def test_should_roll_position_expiry(self, wheel):
         """Test rolling decision based on expiry."""
         position = Position(
-            symbol="U",
+            symbol=TICKER,
             qty=-1,
             avg_price=2.50,
             option_type="put",
@@ -112,7 +115,7 @@ class TestWheelStrategy:
     def test_should_roll_position_deep_itm_put(self, wheel):
         """Test rolling deep ITM put."""
         position = Position(
-            symbol="U",
+            symbol=TICKER,
             qty=-1,
             avg_price=2.50,
             option_type="put",
@@ -131,7 +134,7 @@ class TestWheelStrategy:
     def test_should_roll_position_deep_itm_call(self, wheel):
         """Test rolling deep ITM call."""
         position = Position(
-            symbol="U",
+            symbol=TICKER,
             qty=-1,
             avg_price=2.50,
             option_type="call",
@@ -150,7 +153,7 @@ class TestWheelStrategy:
     def test_should_not_roll_position(self, wheel):
         """Test when position should not be rolled."""
         position = Position(
-            symbol="U",
+            symbol=TICKER,
             qty=-1,
             avg_price=2.50,
             option_type="put",

--- a/tests/test_wheel_backtester.py
+++ b/tests/test_wheel_backtester.py
@@ -6,10 +6,13 @@ from unittest.mock import AsyncMock, Mock, patch
 import numpy as np
 import pandas as pd
 import pytest
+from src.config.loader import get_config
 
 from src.unity_wheel.backtesting import BacktestPosition, BacktestResults, WheelBacktester
 from src.unity_wheel.storage import Storage
 from src.unity_wheel.strategy.wheel import WheelParameters
+
+TICKER = get_config().unity.ticker
 
 
 class TestWheelBacktester:
@@ -96,7 +99,7 @@ class TestWheelBacktester:
 
         # Run backtest
         results = await backtester.backtest_strategy(
-            symbol="U",
+            symbol=TICKER,
             start_date=datetime(2024, 1, 1),
             end_date=datetime(2024, 3, 31),
             initial_capital=100000,
@@ -127,7 +130,7 @@ class TestWheelBacktester:
 
         # Run backtest
         results = await backtester.backtest_strategy(
-            symbol="U",
+            symbol=TICKER,
             start_date=datetime(2024, 1, 1),
             end_date=datetime(2024, 2, 28),
             initial_capital=100000,
@@ -166,7 +169,7 @@ class TestWheelBacktester:
 
         # Run optimization
         results = await backtester.optimize_parameters(
-            symbol="U",
+            symbol=TICKER,
             start_date=datetime(2024, 1, 1),
             end_date=datetime(2024, 3, 31),
             delta_range=(0.25, 0.35),
@@ -184,7 +187,7 @@ class TestWheelBacktester:
         """Test Unity-specific gap risk tracking."""
         # Create position with gap move
         position = BacktestPosition(
-            symbol="U",
+            symbol=TICKER,
             position_type="stock",  # After assignment
             strike=35.0,
             expiration=datetime(2024, 2, 1),
@@ -229,7 +232,7 @@ class TestWheelBacktester:
         """Test position lifecycle management."""
         # Create short put position
         position = BacktestPosition(
-            symbol="U",
+            symbol=TICKER,
             position_type="put",
             strike=35.0,
             expiration=datetime(2024, 2, 15),

--- a/tools/analysis/pull_unity_options.py
+++ b/tools/analysis/pull_unity_options.py
@@ -8,6 +8,11 @@ import os
 import sys
 from datetime import datetime, timedelta
 
+from src.config.loader import get_config
+
+config = get_config()
+TICKER = config.unity.ticker
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from src.unity_wheel.utils.databento_unity import (
@@ -50,7 +55,7 @@ async def main():
         conn = duckdb.connect(db_path)
 
         # Update price history
-        conn.execute("DELETE FROM price_history WHERE symbol = 'U'")
+        conn.execute(f"DELETE FROM price_history WHERE symbol = '{TICKER}'")
 
         for _, row in bars.iterrows():
             conn.execute(
@@ -60,7 +65,7 @@ async def main():
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
             """,
                 [
-                    "U",
+                    TICKER,
                     row["ts_event"].date() if hasattr(row["ts_event"], "date") else row.name.date(),
                     float(row.get("open", row["close"])),
                     float(row.get("high", row["close"])),


### PR DESCRIPTION
## Summary
- add global config fixture for tests
- reference config ticker in tool and tests

## Testing
- `ruff format . && black .`
- `ruff check --fix .`
- `mypy --strict unity_trading data_pipeline ml_engine strategy_engine risk_engine app --ignore-missing-imports` *(fails: ModuleNotFoundError, many type errors)*
- `pip-compile --dry-run` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684860856c5483308969e4bc7464c1ab