### PR TITLE
Unify position imports

### DIFF
--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -10,7 +10,7 @@ import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
-from unity_wheel.models.position import Position, PositionType
+from src.unity_wheel.models.position import Position, PositionType
 
 
 class TestPositionBasic:


### PR DESCRIPTION
## Summary
- ensure tests import the position dataclass from the canonical location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848618148308330b4419dde6ff201dc