### PR TITLE
Improve exception handling and add tests

### DIFF
--- a/clean_database.py
+++ b/clean_database.py
@@ -3,6 +3,10 @@
 import os
 
 import duckdb
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 db_path = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
 conn = duckdb.connect(db_path)
@@ -27,8 +31,8 @@ for table in empty_tables:
         if count == 0:
             print(f"   Dropping empty table: {table}")
             conn.execute(f"DROP TABLE IF EXISTS {table}")
-    except:
-        pass
+    except duckdb.CatalogException as exc:
+        logger.error("Table %s missing: %s", table, exc)
 
 # Fix inverted spreads in options data
 print("\n🔧 FIXING INVERTED SPREADS:")

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -97,8 +97,11 @@ for service in required:
             print(f'✅ {service.capitalize()} credentials found')
         else:
             missing.append(service)
-    except:
+    except Exception as exc:
         missing.append(service)
+        import logging
+        logging.basicConfig(level=logging.ERROR)
+        logging.error("Credential check failed for %s: %s", service, exc)
 
 if missing:
     print(f'❌ Missing credentials: {\", \".join(missing)}')

--- a/scripts/refresh_data.sh
+++ b/scripts/refresh_data.sh
@@ -85,7 +85,10 @@ if os.path.exists(db_path):
             FROM fred_observations
         \"\"\").fetchone()
         print(result[0] if result and result[0] else 999)
-    except:
+    except duckdb.Error as exc:
+        import logging
+        logging.basicConfig(level=logging.ERROR)
+        logging.error("Failed to check FRED age: %s", exc)
         print(999)
     finally:
         conn.close()

--- a/src/unity_wheel/data_providers/base/validation.py
+++ b/src/unity_wheel/data_providers/base/validation.py
@@ -329,7 +329,8 @@ class MarketDataValidator:
         if isinstance(timestamp, str):
             try:
                 timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-            except:
+            except ValueError as exc:
+                logger.error("Invalid timestamp format %s: %s", timestamp, exc)
                 return False
 
         if not isinstance(timestamp, datetime):

--- a/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
+++ b/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
@@ -8,12 +8,15 @@ from datetime import datetime, timedelta
 from typing import Dict, Tuple
 
 import duckdb
+import logging
 
 from src.config.loader import get_config
 
 # Get Unity ticker once
 _config = get_config()
 UNITY_TICKER = _config.unity.ticker
+
+logger = logging.getLogger(__name__)
 
 
 # Colors for terminal output
@@ -69,7 +72,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
                 "records": result[2],
                 "status": "good" if result[1] <= 1 else ("warning" if result[1] <= 7 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to fetch unity price freshness: %s", exc)
         freshness["unity_prices"] = {"status": "error", "records": 0}
 
     # Options data
@@ -99,7 +103,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
             }
         else:
             freshness["options"] = {"status": "error", "records": 0}
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to fetch options freshness: %s", exc)
         freshness["options"] = {"status": "error", "records": 0}
 
     # FRED data
@@ -120,7 +125,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
                 "series_count": result[2],
                 "status": "good" if result[1] <= 7 else ("warning" if result[1] <= 30 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to fetch FRED freshness: %s", exc)
         freshness["fred"] = {"status": "error", "series_count": 0}
 
     return freshness
@@ -150,7 +156,8 @@ def check_data_quality(conn) -> Dict[str, any]:
             "large": gaps[1],
             "status": "good" if gaps[1] == 0 else ("warning" if gaps[1] < 5 else "error"),
         }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to check price gaps: %s", exc)
         quality["price_gaps"] = {"status": "error"}
 
     # Check Unity volatility
@@ -173,7 +180,8 @@ def check_data_quality(conn) -> Dict[str, any]:
                 "max_daily_move": vol[1] * 100,
                 "status": "good" if vol[0] < 1.0 else ("warning" if vol[0] < 1.5 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to check volatility: %s", exc)
         quality["volatility"] = {"status": "error"}
 
     # Check options bid-ask spreads
@@ -201,7 +209,8 @@ def check_data_quality(conn) -> Dict[str, any]:
                     "good" if spreads[0] < 0.1 else ("warning" if spreads[0] < 0.3 else "error")
                 ),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to check option spreads: %s", exc)
         quality["spreads"] = {"status": "none"}
 
     return quality

--- a/src/unity_wheel/risk/pure_borrowing_analyzer.py
+++ b/src/unity_wheel/risk/pure_borrowing_analyzer.py
@@ -138,7 +138,8 @@ class PureBorrowingAnalyzer:
             # Search between -50% and 500% annual return
             daily_irr = brentq(npv_at_rate, -0.5, 5.0, maxiter=100)
             return daily_irr
-        except:
+        except (ValueError, RuntimeError) as exc:
+            logger.error("Failed to compute IRR: %s", exc)
             return None
 
     def analyze_investment(

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -1,0 +1,31 @@
+import logging
+import duckdb
+from src.unity_wheel.data_providers.base.validation import MarketDataValidator
+from src.unity_wheel.monitoring.scripts.data_quality_monitor import check_data_freshness
+from src.unity_wheel.risk.pure_borrowing_analyzer import PureBorrowingAnalyzer
+
+
+def test_check_freshness_invalid_timestamp(caplog):
+    validator = MarketDataValidator()
+    with caplog.at_level(logging.ERROR):
+        assert validator._check_freshness("bad timestamp", 5) is False
+    assert "Invalid timestamp format" in caplog.text
+
+
+def test_calculate_irr_logging(caplog):
+    analyzer = PureBorrowingAnalyzer()
+    flows = [(0, -100), (1, -150)]
+    with caplog.at_level(logging.ERROR):
+        irr = analyzer.calculate_irr(flows)
+    assert irr is None
+    assert "Failed to compute IRR" in caplog.text
+
+
+def test_check_data_freshness_missing_tables(caplog):
+    conn = duckdb.connect(":memory:")
+    with caplog.at_level(logging.ERROR):
+        result = check_data_freshness(conn)
+    assert result["unity_prices"]["status"] == "error"
+    assert result["options"]["status"] == "error"
+    assert result["fred"]["status"] == "error"
+    assert "Failed to fetch unity price freshness" in caplog.text

--- a/tools/debug/debug_databento.py
+++ b/tools/debug/debug_databento.py
@@ -10,6 +10,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from src.unity_wheel.databento import DatabentoClient
 from src.unity_wheel.utils import setup_structured_logging
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 async def debug_databento():
@@ -114,8 +117,8 @@ async def debug_databento():
         try:
             # This would require admin API access
             print("   Note: Full dataset listing requires admin access")
-        except:
-            pass
+        except Exception as exc:
+            logger.error("Failed to list datasets: %s", exc)
 
     finally:
         await client.close()

--- a/tools/fill_unity_options.py
+++ b/tools/fill_unity_options.py
@@ -8,12 +8,16 @@ import sys
 from datetime import datetime, timedelta
 
 import duckdb
+import logging
 
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
 DB_PATH = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -157,8 +161,14 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass  # Skip if already exists
+                except duckdb.ConstraintException as exc:
+                    logger.warning(
+                        "Duplicate option for %s %s %.2f: %s",
+                        min_exp,
+                        opt_type,
+                        strike,
+                        exc,
+                    )
 
         if options_added % 100 == 0:
             print(f"\r   Added {options_added:,} options...", end="")
@@ -241,8 +251,14 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass
+                except duckdb.ConstraintException as exc:
+                    logger.warning(
+                        "Duplicate weekly option for %s %s %.2f: %s",
+                        weekly_exp,
+                        opt_type,
+                        atm_strike,
+                        exc,
+                    )
 
     conn.commit()
 

--- a/tools/generate_missing_unity_options.py
+++ b/tools/generate_missing_unity_options.py
@@ -8,12 +8,16 @@ import sys
 from datetime import datetime, timedelta
 
 import duckdb
+import logging
 
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
 DB_PATH = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def get_monthly_expirations(year, month):
@@ -228,8 +232,8 @@ def main():
                     )
                     inserted += 1
                     options_added += 1
-                except:
-                    pass  # Skip duplicates
+                except duckdb.ConstraintException as exc:
+                    logger.warning("Duplicate option for %s: %s", expiration, exc)
 
             if inserted > 0:
                 print(f"   Added {inserted} options for {expiration} expiration")


### PR DESCRIPTION
## Summary
- replace bare except clauses with specific exceptions and add logging
- log failures in scripts
- cover new exception paths with unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848619132ac8330939a4528d6354b94