### PR TITLE
Improve exception handling

### DIFF
--- a/clean_database.py
+++ b/clean_database.py
@@ -3,6 +3,11 @@
 import os
 
 import duckdb
+import logging
+
+from src.unity_wheel.utils.logging import StructuredLogger
+
+logger = StructuredLogger(logging.getLogger(__name__))
 
 db_path = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
 conn = duckdb.connect(db_path)
@@ -27,8 +32,8 @@ for table in empty_tables:
         if count == 0:
             print(f"   Dropping empty table: {table}")
             conn.execute(f"DROP TABLE IF EXISTS {table}")
-    except:
-        pass
+    except duckdb.Error as exc:
+        logger.exception("Failed to drop table", exc_info=exc)
 
 # Fix inverted spreads in options data
 print("\n🔧 FIXING INVERTED SPREADS:")

--- a/src/unity_wheel/data_providers/base/validation.py
+++ b/src/unity_wheel/data_providers/base/validation.py
@@ -329,7 +329,8 @@ class MarketDataValidator:
         if isinstance(timestamp, str):
             try:
                 timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-            except:
+            except ValueError as exc:
+                logger.exception("Invalid timestamp format", exc_info=exc)
                 return False
 
         if not isinstance(timestamp, datetime):

--- a/src/unity_wheel/risk/pure_borrowing_analyzer.py
+++ b/src/unity_wheel/risk/pure_borrowing_analyzer.py
@@ -138,7 +138,8 @@ class PureBorrowingAnalyzer:
             # Search between -50% and 500% annual return
             daily_irr = brentq(npv_at_rate, -0.5, 5.0, maxiter=100)
             return daily_irr
-        except:
+        except (ValueError, RuntimeError) as exc:
+            logger.exception("Failed to calculate IRR", exc_info=exc)
             return None
 
     def analyze_investment(

--- a/tests/test_error_logging.py
+++ b/tests/test_error_logging.py
@@ -1,0 +1,40 @@
+import types
+import duckdb
+import pytest
+
+from src.unity_wheel.risk.pure_borrowing_analyzer import PureBorrowingAnalyzer
+from src.unity_wheel.monitoring.scripts import data_quality_monitor as dqm
+from src.unity_wheel.data_providers.base.validation import MarketDataValidator
+
+
+class FailingConn:
+    def execute(self, *args, **kwargs):
+        raise duckdb.Error("fail")
+
+
+def test_calculate_irr_logs_error(caplog, monkeypatch):
+    monkeypatch.setattr(
+        "src.unity_wheel.risk.pure_borrowing_analyzer.get_config",
+        lambda: types.SimpleNamespace(),
+    )
+    analyzer = PureBorrowingAnalyzer()
+    cash_flows = [(0, 100), (30, 100)]
+    with caplog.at_level("ERROR"):
+        irr = analyzer.calculate_irr(cash_flows)
+    assert irr is None
+    assert any("Failed to calculate IRR" in r.message for r in caplog.records)
+
+
+def test_check_data_freshness_error(caplog):
+    with caplog.at_level("ERROR"):
+        result = dqm.check_data_freshness(FailingConn())
+    assert result["unity_prices"]["status"] == "error"
+    assert any("Failed to check unity_prices freshness" in r.message for r in caplog.records)
+
+
+def test_validation_check_freshness_error(caplog):
+    validator = MarketDataValidator()
+    with caplog.at_level("ERROR"):
+        ok = validator._check_freshness("bad", 5)
+    assert ok is False
+    assert any("Invalid timestamp format" in r.message for r in caplog.records)

--- a/tools/debug/debug_databento.py
+++ b/tools/debug/debug_databento.py
@@ -4,12 +4,15 @@
 import asyncio
 import os
 import sys
+import logging
 from datetime import datetime, timedelta, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from src.unity_wheel.databento import DatabentoClient
-from src.unity_wheel.utils import setup_structured_logging
+from src.unity_wheel.utils import setup_structured_logging, get_logger
+
+logger = get_logger(__name__)
 
 
 async def debug_databento():
@@ -114,8 +117,8 @@ async def debug_databento():
         try:
             # This would require admin API access
             print("   Note: Full dataset listing requires admin access")
-        except:
-            pass
+        except Exception as exc:
+            logger.exception("Failed to list datasets", exc_info=exc)
 
     finally:
         await client.close()

--- a/tools/fill_unity_options.py
+++ b/tools/fill_unity_options.py
@@ -8,6 +8,11 @@ import sys
 from datetime import datetime, timedelta
 
 import duckdb
+import logging
+
+from src.unity_wheel.utils.logging import StructuredLogger
+
+logger = StructuredLogger(logging.getLogger(__name__))
 
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -157,8 +162,8 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass  # Skip if already exists
+                except duckdb.Error as exc:
+                    logger.exception("Failed to insert option", exc_info=exc)
 
         if options_added % 100 == 0:
             print(f"\r   Added {options_added:,} options...", end="")
@@ -241,8 +246,8 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass
+                except duckdb.Error as exc:
+                    logger.exception("Failed to insert weekly option", exc_info=exc)
 
     conn.commit()
 

--- a/tools/generate_missing_unity_options.py
+++ b/tools/generate_missing_unity_options.py
@@ -8,6 +8,11 @@ import sys
 from datetime import datetime, timedelta
 
 import duckdb
+import logging
+
+from src.unity_wheel.utils.logging import StructuredLogger
+
+logger = StructuredLogger(logging.getLogger(__name__))
 
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -228,8 +233,8 @@ def main():
                     )
                     inserted += 1
                     options_added += 1
-                except:
-                    pass  # Skip duplicates
+                except duckdb.Error as exc:
+                    logger.exception("Failed to insert option", exc_info=exc)
 
             if inserted > 0:
                 print(f"   Added {inserted} options for {expiration} expiration")


### PR DESCRIPTION
## Summary
- replace `except:` with specific exception handling
- log failures with StructuredLogger
- add regression tests for new logging paths

## Testing
- `pytest tests/test_error_logging.py -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_68486199a9e0833086e6e08769cc67b9