### PR TITLE
Replace bare exceptions with specific errors and tests

### DIFF
--- a/clean_database.py
+++ b/clean_database.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 """Clean up database - remove empty tables and fix data issues."""
+
 import os
 
+import logging
 import duckdb
+
+from src.unity_wheel.utils.logging import StructuredLogger
+
+logger = StructuredLogger(logging.getLogger(__name__))
 
 db_path = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
 conn = duckdb.connect(db_path)
@@ -27,8 +33,8 @@ for table in empty_tables:
         if count == 0:
             print(f"   Dropping empty table: {table}")
             conn.execute(f"DROP TABLE IF EXISTS {table}")
-    except:
-        pass
+    except duckdb.Error as exc:
+        logger.warning("Failed to check or drop table", extra={"table": table, "error": str(exc)})
 
 # Fix inverted spreads in options data
 print("\n🔧 FIXING INVERTED SPREADS:")

--- a/src/unity_wheel/data_providers/base/validation.py
+++ b/src/unity_wheel/data_providers/base/validation.py
@@ -329,7 +329,10 @@ class MarketDataValidator:
         if isinstance(timestamp, str):
             try:
                 timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-            except:
+            except ValueError as exc:
+                logger.warning(
+                    "Invalid timestamp format", extra={"timestamp": timestamp, "error": str(exc)}
+                )
                 return False
 
         if not isinstance(timestamp, datetime):

--- a/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
+++ b/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
@@ -7,9 +7,14 @@ import time
 from datetime import datetime, timedelta
 from typing import Dict, Tuple
 
+import logging
 import duckdb
 
+from src.unity_wheel.utils.logging import StructuredLogger, get_logger
+
 from src.config.loader import get_config
+
+logger = get_logger(__name__)
 
 # Get Unity ticker once
 _config = get_config()
@@ -69,7 +74,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
                 "records": result[2],
                 "status": "good" if result[1] <= 1 else ("warning" if result[1] <= 7 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to query price freshness", extra={"error": str(exc)})
         freshness["unity_prices"] = {"status": "error", "records": 0}
 
     # Options data
@@ -99,7 +105,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
             }
         else:
             freshness["options"] = {"status": "error", "records": 0}
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to query options freshness", extra={"error": str(exc)})
         freshness["options"] = {"status": "error", "records": 0}
 
     # FRED data
@@ -120,7 +127,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
                 "series_count": result[2],
                 "status": "good" if result[1] <= 7 else ("warning" if result[1] <= 30 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to query FRED freshness", extra={"error": str(exc)})
         freshness["fred"] = {"status": "error", "series_count": 0}
 
     return freshness
@@ -150,7 +158,8 @@ def check_data_quality(conn) -> Dict[str, any]:
             "large": gaps[1],
             "status": "good" if gaps[1] == 0 else ("warning" if gaps[1] < 5 else "error"),
         }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to query price gaps", extra={"error": str(exc)})
         quality["price_gaps"] = {"status": "error"}
 
     # Check Unity volatility
@@ -173,7 +182,8 @@ def check_data_quality(conn) -> Dict[str, any]:
                 "max_daily_move": vol[1] * 100,
                 "status": "good" if vol[0] < 1.0 else ("warning" if vol[0] < 1.5 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to query volatility", extra={"error": str(exc)})
         quality["volatility"] = {"status": "error"}
 
     # Check options bid-ask spreads
@@ -201,7 +211,8 @@ def check_data_quality(conn) -> Dict[str, any]:
                     "good" if spreads[0] < 0.1 else ("warning" if spreads[0] < 0.3 else "error")
                 ),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed to query spreads", extra={"error": str(exc)})
         quality["spreads"] = {"status": "none"}
 
     return quality

--- a/src/unity_wheel/risk/pure_borrowing_analyzer.py
+++ b/src/unity_wheel/risk/pure_borrowing_analyzer.py
@@ -138,7 +138,8 @@ class PureBorrowingAnalyzer:
             # Search between -50% and 500% annual return
             daily_irr = brentq(npv_at_rate, -0.5, 5.0, maxiter=100)
             return daily_irr
-        except:
+        except (ValueError, RuntimeError) as exc:
+            logger.error("IRR calculation failed", extra={"error": str(exc)})
             return None
 
     def analyze_investment(

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -1,0 +1,55 @@
+import importlib
+import logging
+import importlib
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+def _setup_fake_duckdb(monkeypatch):
+    class FakeError(Exception):
+        pass
+
+    fake_module = SimpleNamespace(Error=FakeError)
+    monkeypatch.setitem(sys.modules, "duckdb", fake_module)
+    return fake_module
+
+
+def test_check_freshness_invalid_timestamp(monkeypatch, caplog):
+    _setup_fake_duckdb(monkeypatch)
+    from src.unity_wheel.data_providers.base.validation import MarketDataValidator
+
+    validator = MarketDataValidator()
+    with caplog.at_level(logging.WARNING):
+        assert not validator._check_freshness("bad-date", 5)
+    assert "Invalid timestamp format" in caplog.text
+
+
+def test_data_quality_monitor_db_error(monkeypatch, caplog):
+    fake = _setup_fake_duckdb(monkeypatch)
+    dqm = importlib.reload(
+        importlib.import_module("src.unity_wheel.monitoring.scripts.data_quality_monitor")
+    )
+
+    class BadConn:
+        def execute(self, *args, **kwargs):
+            raise fake.Error("boom")
+
+    with caplog.at_level(logging.ERROR):
+        result = dqm.check_data_freshness(BadConn())
+    assert result["unity_prices"]["status"] == "error"
+    assert "price freshness" in caplog.text
+
+
+def test_calculate_irr_failure_logs(caplog):
+    from src.unity_wheel.risk.pure_borrowing_analyzer import PureBorrowingAnalyzer
+
+    analyzer = PureBorrowingAnalyzer()
+    cash_flows = [(0, -100), (10, -50)]
+
+    with caplog.at_level(logging.ERROR):
+        result = analyzer.calculate_irr(cash_flows)
+    assert result is None
+    assert "IRR calculation failed" in caplog.text

--- a/tools/debug/debug_databento.py
+++ b/tools/debug/debug_databento.py
@@ -2,6 +2,7 @@
 """Debug Databento connection and data retrieval."""
 
 import asyncio
+import logging
 import os
 import sys
 from datetime import datetime, timedelta, timezone
@@ -10,6 +11,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from src.unity_wheel.databento import DatabentoClient
 from src.unity_wheel.utils import setup_structured_logging
+from src.unity_wheel.utils.logging import StructuredLogger
+
+logger = StructuredLogger(logging.getLogger(__name__))
 
 
 async def debug_databento():
@@ -114,8 +118,8 @@ async def debug_databento():
         try:
             # This would require admin API access
             print("   Note: Full dataset listing requires admin access")
-        except:
-            pass
+        except Exception as exc:
+            logger.error("Failed to list datasets", extra={"error": str(exc)})
 
     finally:
         await client.close()

--- a/tools/fill_unity_options.py
+++ b/tools/fill_unity_options.py
@@ -3,11 +3,16 @@
 Fill remaining Unity options data to reach target of ~13,230 options.
 Simplified version without timezone issues.
 """
+import logging
 import os
 import sys
 from datetime import datetime, timedelta
 
 import duckdb
+
+from src.unity_wheel.utils.logging import StructuredLogger
+
+logger = StructuredLogger(logging.getLogger(__name__))
 
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -157,8 +162,11 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass  # Skip if already exists
+                except duckdb.Error as exc:
+                    logger.debug(
+                        "Duplicate option",
+                        extra={"expiration": expiration, "strike": strike, "error": str(exc)},
+                    )  # Skip if already exists
 
         if options_added % 100 == 0:
             print(f"\r   Added {options_added:,} options...", end="")
@@ -241,8 +249,11 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass
+                except duckdb.Error as exc:
+                    logger.debug(
+                        "Duplicate option",
+                        extra={"expiration": expiration, "strike": strike, "error": str(exc)},
+                    )
 
     conn.commit()
 

--- a/tools/generate_missing_unity_options.py
+++ b/tools/generate_missing_unity_options.py
@@ -3,11 +3,16 @@
 Generate missing Unity options data to complete the dataset.
 This will create synthetic but realistic options data for dates that are missing.
 """
+import logging
 import os
 import sys
 from datetime import datetime, timedelta
 
 import duckdb
+
+from src.unity_wheel.utils.logging import StructuredLogger
+
+logger = StructuredLogger(logging.getLogger(__name__))
 
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -228,8 +233,15 @@ def main():
                     )
                     inserted += 1
                     options_added += 1
-                except:
-                    pass  # Skip duplicates
+                except duckdb.Error as exc:
+                    logger.debug(
+                        "Duplicate option",
+                        extra={
+                            "expiration": expiration,
+                            "strike": opt.get("strike"),
+                            "error": str(exc),
+                        },
+                    )  # Skip duplicates
 
             if inserted > 0:
                 print(f"   Added {inserted} options for {expiration} expiration")


### PR DESCRIPTION
## Summary
- catch duckdb exceptions in `data_quality_monitor.py` and log failures
- log invalid timestamp errors in validation helper
- handle IRR calculation errors in `pure_borrowing_analyzer`
- fix scripts in tools to avoid bare `except:` clauses
- add regression tests for logging paths

## Testing
- `ruff format . && black . && ruff check --fix . && mypy --strict unity_trading data_pipeline ml_engine strategy_engine risk_engine app --ignore-missing-imports`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848635b48588330acc556f0bed268b2