### PR TITLE
Improve exception handling and tests

### DIFF
--- a/clean_database.py
+++ b/clean_database.py
@@ -4,6 +4,10 @@ import os
 
 import duckdb
 
+from src.unity_wheel.utils import get_logger
+
+logger = get_logger(__name__)
+
 db_path = os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb")
 conn = duckdb.connect(db_path)
 
@@ -27,8 +31,8 @@ for table in empty_tables:
         if count == 0:
             print(f"   Dropping empty table: {table}")
             conn.execute(f"DROP TABLE IF EXISTS {table}")
-    except:
-        pass
+    except duckdb.Error as exc:
+        logger.warning("Failed to drop table", extra={"table": table, "error": str(exc)})
 
 # Fix inverted spreads in options data
 print("\n🔧 FIXING INVERTED SPREADS:")

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -97,7 +97,8 @@ for service in required:
             print(f'✅ {service.capitalize()} credentials found')
         else:
             missing.append(service)
-    except:
+    except Exception as exc:
+        print(f'Error retrieving {service} credentials: {exc}')
         missing.append(service)
 
 if missing:

--- a/scripts/refresh_data.sh
+++ b/scripts/refresh_data.sh
@@ -85,8 +85,9 @@ if os.path.exists(db_path):
             FROM fred_observations
         \"\"\").fetchone()
         print(result[0] if result and result[0] else 999)
-    except:
+    except Exception as exc:
         print(999)
+        print(f'Error checking FRED data: {exc}')
     finally:
         conn.close()
 else:

--- a/src/unity_wheel/data_providers/base/validation.py
+++ b/src/unity_wheel/data_providers/base/validation.py
@@ -329,7 +329,10 @@ class MarketDataValidator:
         if isinstance(timestamp, str):
             try:
                 timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-            except:
+            except ValueError as exc:
+                logger.warning(
+                    "Invalid timestamp format", extra={"timestamp": timestamp, "error": str(exc)}
+                )
                 return False
 
         if not isinstance(timestamp, datetime):

--- a/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
+++ b/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
@@ -9,6 +9,10 @@ from typing import Dict, Tuple
 
 import duckdb
 
+from src.unity_wheel.utils import get_logger
+
+logger = get_logger(__name__)
+
 from src.config.loader import get_config
 
 # Get Unity ticker once
@@ -69,7 +73,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
                 "records": result[2],
                 "status": "good" if result[1] <= 1 else ("warning" if result[1] <= 7 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.warning("Failed to fetch unity price freshness", extra={"error": str(exc)})
         freshness["unity_prices"] = {"status": "error", "records": 0}
 
     # Options data
@@ -99,7 +104,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
             }
         else:
             freshness["options"] = {"status": "error", "records": 0}
-    except:
+    except duckdb.Error as exc:
+        logger.warning("Failed to fetch options freshness", extra={"error": str(exc)})
         freshness["options"] = {"status": "error", "records": 0}
 
     # FRED data
@@ -120,7 +126,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
                 "series_count": result[2],
                 "status": "good" if result[1] <= 7 else ("warning" if result[1] <= 30 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.warning("Failed to fetch FRED freshness", extra={"error": str(exc)})
         freshness["fred"] = {"status": "error", "series_count": 0}
 
     return freshness
@@ -150,7 +157,8 @@ def check_data_quality(conn) -> Dict[str, any]:
             "large": gaps[1],
             "status": "good" if gaps[1] == 0 else ("warning" if gaps[1] < 5 else "error"),
         }
-    except:
+    except duckdb.Error as exc:
+        logger.warning("Failed to check price gaps", extra={"error": str(exc)})
         quality["price_gaps"] = {"status": "error"}
 
     # Check Unity volatility
@@ -173,7 +181,8 @@ def check_data_quality(conn) -> Dict[str, any]:
                 "max_daily_move": vol[1] * 100,
                 "status": "good" if vol[0] < 1.0 else ("warning" if vol[0] < 1.5 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.warning("Failed to check volatility", extra={"error": str(exc)})
         quality["volatility"] = {"status": "error"}
 
     # Check options bid-ask spreads
@@ -201,7 +210,8 @@ def check_data_quality(conn) -> Dict[str, any]:
                     "good" if spreads[0] < 0.1 else ("warning" if spreads[0] < 0.3 else "error")
                 ),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.warning("Failed to check option spreads", extra={"error": str(exc)})
         quality["spreads"] = {"status": "none"}
 
     return quality

--- a/src/unity_wheel/risk/pure_borrowing_analyzer.py
+++ b/src/unity_wheel/risk/pure_borrowing_analyzer.py
@@ -138,7 +138,8 @@ class PureBorrowingAnalyzer:
             # Search between -50% and 500% annual return
             daily_irr = brentq(npv_at_rate, -0.5, 5.0, maxiter=100)
             return daily_irr
-        except:
+        except (ValueError, RuntimeError) as exc:
+            logger.warning("IRR calculation failed", extra={"error": str(exc)})
             return None
 
     def analyze_investment(

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -1,0 +1,30 @@
+import logging
+import duckdb
+
+from src.unity_wheel.data_providers.base.validation import MarketDataValidator
+from src.unity_wheel.monitoring.scripts.data_quality_monitor import check_data_freshness
+from src.unity_wheel.risk.pure_borrowing_analyzer import PureBorrowingAnalyzer
+
+
+def test_check_freshness_invalid_timestamp(caplog):
+    validator = MarketDataValidator()
+    with caplog.at_level(logging.WARNING):
+        assert validator._check_freshness("bad timestamp", 5) is False
+        assert "Invalid timestamp format" in caplog.text
+
+
+def test_check_data_freshness_db_error(caplog):
+    conn = duckdb.connect(":memory:")
+    with caplog.at_level(logging.WARNING):
+        result = check_data_freshness(conn)
+        assert result["unity_prices"]["status"] == "error"
+        assert "Failed to fetch unity price freshness" in caplog.text
+
+
+def test_calculate_irr_failure(caplog):
+    analyzer = PureBorrowingAnalyzer()
+    cash_flows = [(0, -100), (10, -10)]  # no sign change -> brentq fails
+    with caplog.at_level(logging.WARNING):
+        irr = analyzer.calculate_irr(cash_flows)
+        assert irr is None
+        assert "IRR calculation failed" in caplog.text

--- a/tools/debug/debug_databento.py
+++ b/tools/debug/debug_databento.py
@@ -9,7 +9,9 @@ from datetime import datetime, timedelta, timezone
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from src.unity_wheel.databento import DatabentoClient
-from src.unity_wheel.utils import setup_structured_logging
+from src.unity_wheel.utils import get_logger, setup_structured_logging
+
+logger = get_logger(__name__)
 
 
 async def debug_databento():
@@ -114,8 +116,8 @@ async def debug_databento():
         try:
             # This would require admin API access
             print("   Note: Full dataset listing requires admin access")
-        except:
-            pass
+        except Exception as exc:
+            logger.debug("Dataset listing failed", extra={"error": str(exc)})
 
     finally:
         await client.close()

--- a/tools/fill_unity_options.py
+++ b/tools/fill_unity_options.py
@@ -9,6 +9,10 @@ from datetime import datetime, timedelta
 
 import duckdb
 
+from src.unity_wheel.utils import get_logger
+
+logger = get_logger(__name__)
+
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
@@ -157,8 +161,8 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass  # Skip if already exists
+                except duckdb.Error as exc:
+                    logger.debug("Duplicate option skipped", extra={"error": str(exc)})
 
         if options_added % 100 == 0:
             print(f"\r   Added {options_added:,} options...", end="")
@@ -241,8 +245,8 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass
+                except duckdb.Error as exc:
+                    logger.debug("Duplicate weekly option skipped", extra={"error": str(exc)})
 
     conn.commit()
 

--- a/tools/generate_missing_unity_options.py
+++ b/tools/generate_missing_unity_options.py
@@ -9,6 +9,10 @@ from datetime import datetime, timedelta
 
 import duckdb
 
+from src.unity_wheel.utils import get_logger
+
+logger = get_logger(__name__)
+
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
@@ -228,8 +232,8 @@ def main():
                     )
                     inserted += 1
                     options_added += 1
-                except:
-                    pass  # Skip duplicates
+                except duckdb.Error as exc:
+                    logger.debug("Duplicate option skipped", extra={"error": str(exc)})
 
             if inserted > 0:
                 print(f"   Added {inserted} options for {expiration} expiration")


### PR DESCRIPTION
## Summary
- replace bare `except:` blocks with specific exceptions and logging
- log database cleanup failures
- avoid silent errors in shell scripts
- add regression tests for new logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848641a35308330a6dab16f605ae3f7