### PR TITLE
Replace hard-coded Unity ticker usage

### DIFF
--- a/check_synthetic_data.py
+++ b/check_synthetic_data.py
@@ -25,10 +25,14 @@ sample = conn.execute(
 print("\n📊 Sample Options Data:")
 print("-" * 80)
 for row in sample[:3]:
+    spread = row[3] - row[2]
     print(f"Strike ${row[0]} {row[1]} @ {row[9]}")
-    print(f"  Prices: Bid=${row[2]:.2f} Ask=${row[3]:.2f} Spread=${row[3]-row[2]:.2f}")
+    print(f"  Prices: Bid=${row[2]:.2f} Ask=${row[3]:.2f} Spread=${spread:.2f}")
     print(f"  Volume={row[4]:,} OI={row[5]:,}")
-    print(f"  Greeks: IV={row[6]:.3f} Delta={row[7]:.3f} Gamma={row[8]:.3f} Theta={row[9]:.3f}")
+    print(
+        "  Greeks: IV="
+        f"{row[6]:.3f} Delta={row[7]:.3f} Gamma={row[8]:.3f} Theta={row[9]:.3f}"
+    )
     print()
 
 # Analyze data patterns
@@ -67,8 +71,12 @@ formula_check = conn.execute(
         -- Check if all gammas are positive
         SUM(CASE WHEN gamma < 0 THEN 1 ELSE 0 END) as negative_gammas,
         -- Check delta ranges
-        SUM(CASE WHEN option_type = 'PUT' AND delta > 0 THEN 1 ELSE 0 END) as wrong_put_deltas,
-        SUM(CASE WHEN option_type = 'CALL' AND delta < 0 THEN 1 ELSE 0 END) as wrong_call_deltas
+        SUM(
+            CASE WHEN option_type = 'PUT' AND delta > 0 THEN 1 ELSE 0 END
+        ) as wrong_put_deltas,
+        SUM(
+            CASE WHEN option_type = 'CALL' AND delta < 0 THEN 1 ELSE 0 END
+        ) as wrong_call_deltas
     FROM databento_option_chains
     WHERE symbol = 'U'
 """

--- a/clean_database.py
+++ b/clean_database.py
@@ -27,7 +27,7 @@ for table in empty_tables:
         if count == 0:
             print(f"   Dropping empty table: {table}")
             conn.execute(f"DROP TABLE IF EXISTS {table}")
-    except:
+    except Exception:
         pass
 
 # Fix inverted spreads in options data
@@ -109,7 +109,9 @@ unity_quality = conn.execute(
     SELECT
         'Options' as data_type,
         COUNT(*) as records,
-        SUM(CASE WHEN bid > ask OR bid < 0 OR ask < 0 THEN 1 ELSE 0 END) as quality_issues
+        SUM(
+            CASE WHEN bid > ask OR bid < 0 OR ask < 0 THEN 1 ELSE 0 END
+        ) as quality_issues
     FROM databento_option_chains
     WHERE symbol = 'U'
 """

--- a/final_database_check.py
+++ b/final_database_check.py
@@ -46,10 +46,11 @@ stock_check = conn.execute(
 """
 ).fetchone()
 
-print(f"\n   📊 Stock Data:")
+print("\n   📊 Stock Data:")
 print(f"      Records: {stock_check[0]:,}")
 print(f"      Period: {stock_check[2]} to {stock_check[3]}")
-print(f"      Data Quality: {'✅ PERFECT' if stock_check[4] == 0 else '❌ Issues found'}")
+stock_quality = "✅ PERFECT" if stock_check[4] == 0 else "❌ Issues found"
+print(f"      Data Quality: {stock_quality}")
 
 # Options data
 options_check = conn.execute(
@@ -66,22 +67,28 @@ options_check = conn.execute(
 """
 ).fetchone()
 
-print(f"\n   📈 Options Data:")
+print("\n   📈 Options Data:")
 print(f"      Records: {options_check[0]:,}")
 print(f"      Period: {options_check[4]} to {options_check[5]}")
 print(f"      Inverted Spreads: {options_check[2]}")
 print(f"      Negative Prices: {options_check[3]}")
-print(
-    f"      Data Quality: {'✅ PERFECT' if options_check[2] == 0 and options_check[3] == 0 else '❌ Issues remain'}"
+opts_quality = (
+    "✅ PERFECT"
+    if options_check[2] == 0 and options_check[3] == 0
+    else "❌ Issues remain"
 )
+print(f"      Data Quality: {opts_quality}")
 
 # FRED data verification
 print("\n💹 FRED DATA:")
 fred_series = conn.execute(
     """
-    SELECT COUNT(DISTINCT series_id), COUNT(*), MIN(calculation_date), MAX(calculation_date)
+    SELECT COUNT(DISTINCT series_id),
+           COUNT(*),
+           MIN(calculation_date),
+           MAX(calculation_date)
     FROM fred_features
-"""
+    """
 ).fetchone()
 
 print(f"   Series: {fred_series[0]}")

--- a/final_unity_status.py
+++ b/final_unity_status.py
@@ -18,7 +18,7 @@ stock = conn.execute(
 """
 ).fetchone()
 
-print(f"\n📊 STOCK DATA: ✅ COMPLETE")
+print("\n📊 STOCK DATA: ✅ COMPLETE")
 print(f"   Records: {stock[0]:,}")
 print(f"   Period: {stock[1]} to {stock[2]}")
 print(f"   Price range: ${stock[3]:.2f} - ${stock[4]:.2f}")
@@ -38,7 +38,7 @@ options = conn.execute(
 """
 ).fetchone()
 
-print(f"\n📈 OPTIONS DATA: ✅ COMPLETE")
+print("\n📈 OPTIONS DATA: ✅ COMPLETE")
 print(f"   Records: {options[0]:,} (97.5% of ~13,230 target)")
 print(f"   Trading days: {options[1]}")
 print(f"   Expirations: {options[2]}")
@@ -46,13 +46,13 @@ print(f"   Strikes: {options[3]}")
 print(f"   Period: {options[4]} to {options[5]}")
 
 # Compliance check
-print(f"\n✅ SPECIFICATION COMPLIANCE:")
-print(f"   ✅ Stock data: Jan 2022 - Jun 2025")
-print(f"   ✅ Options data: Jan 2023 - Jun 2025")
-print(f"   ✅ Strike range: 70-130% of spot price")
-print(f"   ✅ Monthly expirations only")
-print(f"   ✅ 21-49 DTE filter applied")
-print(f"   ✅ All required fields populated")
+print("\n✅ SPECIFICATION COMPLIANCE:")
+print("   ✅ Stock data: Jan 2022 - Jun 2025")
+print("   ✅ Options data: Jan 2023 - Jun 2025")
+print("   ✅ Strike range: 70-130% of spot price")
+print("   ✅ Monthly expirations only")
+print("   ✅ 21-49 DTE filter applied")
+print("   ✅ All required fields populated")
 
-print(f"\n🎉 SUCCESS! Unity dataset is perfect and ready for use!")
+print("\n🎉 SUCCESS! Unity dataset is perfect and ready for use!")
 conn.close()

--- a/src/unity_wheel/__init__.py
+++ b/src/unity_wheel/__init__.py
@@ -1,9 +1,8 @@
 """Unity Wheel Bot - Sophisticated options wheel trading system."""
 
 from .__version__ import API_VERSION, __version__, __version_info__, get_version_string
-from .api import MarketSnapshot, Recommendation
+from .api import MarketSnapshot, Recommendation, WheelAdvisor
 from .api import RiskMetrics as ApiRiskMetrics
-from .api import WheelAdvisor
 from .math import (
     CalculationResult,
     black_scholes_price_validated,

--- a/src/unity_wheel/cli/databento_integration.py
+++ b/src/unity_wheel/cli/databento_integration.py
@@ -20,13 +20,13 @@ logger = logging.getLogger(__name__)
 
 async def create_databento_market_snapshot(
     portfolio_value: float,
-    ticker: str = "U",
+    ticker: str | None = None,
 ) -> tuple[MarketSnapshot, float]:
     """Create market snapshot from real Databento data.
 
     Args:
         portfolio_value: Total portfolio value
-        ticker: Stock ticker (default: "U" for Unity)
+        ticker: Stock ticker (defaults to config value)
 
     Returns:
         MarketSnapshot with real Unity options data
@@ -35,6 +35,7 @@ async def create_databento_market_snapshot(
         ValueError: If unable to fetch real Unity options data
     """
     # Load API key via SecretInjector
+    ticker = ticker or get_settings().unity.ticker
     with SecretInjector(service="databento"):
         client = DatabentoClient()
         integration = DatabentoIntegration(client)
@@ -133,12 +134,12 @@ async def create_databento_market_snapshot(
             await client.close()
 
 
-def get_market_data_sync(portfolio_value: float, ticker: str = "U") -> tuple[MarketSnapshot, float]:
+def get_market_data_sync(portfolio_value: float, ticker: str | None = None) -> tuple[MarketSnapshot, float]:
     """Synchronous wrapper for getting market data.
 
     Args:
         portfolio_value: Total portfolio value
-        ticker: Stock ticker (default: "U" for Unity)
+        ticker: Stock ticker (defaults to config value)
 
     Returns:
         MarketSnapshot with real Unity options data
@@ -150,6 +151,7 @@ def get_market_data_sync(portfolio_value: float, ticker: str = "U") -> tuple[Mar
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
+        ticker = ticker or get_settings().unity.ticker
         return loop.run_until_complete(create_databento_market_snapshot(portfolio_value, ticker))
     finally:
         loop.close()

--- a/src/unity_wheel/data_providers/databento/client.py
+++ b/src/unity_wheel/data_providers/databento/client.py
@@ -213,13 +213,14 @@ class DatabentoClient:
                 )
                 symbol_formats = [(symbols, stype_in)]
             else:
+                unity_ticker = get_config().unity.ticker
                 # Handle Unity-specific symbol format
-                if underlying == "U":
+                if underlying == unity_ticker:
                     # Unity requires special handling - try multiple formats
                     symbol_formats = [
-                        (["U.OPT"], SType.PARENT),  # Standard format first
-                        (["U     *"], SType.PARENT),  # Unity with 5 spaces
-                        (["U"], SType.RAW_SYMBOL),  # Raw symbol
+                        ([f"{unity_ticker}.OPT"], SType.PARENT),  # Standard format first
+                        ([f"{unity_ticker}     *"], SType.PARENT),
+                        ([unity_ticker], SType.RAW_SYMBOL),
                     ]
                 else:
                     symbol_formats = [

--- a/src/unity_wheel/data_providers/validation/live_data_validator.py
+++ b/src/unity_wheel/data_providers/validation/live_data_validator.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from src.unity_wheel.utils import get_logger
+from src.config.loader import get_config
 
 logger = get_logger(__name__)
 
@@ -95,7 +96,8 @@ class LiveDataValidator:
                     logger.warning(f"Suspicious environment variable: {key}={value}")
 
     @classmethod
-    def validate_price(cls, price: float, symbol: str = "U") -> None:
+    def validate_price(cls, price: float, symbol: str | None = None) -> None:
+        symbol = symbol or get_config().unity.ticker
         """Validate that a price looks like real market data."""
         if price <= 0:
             raise ValueError(f"Invalid price {price} for {symbol} - must be positive")
@@ -107,7 +109,7 @@ class LiveDataValidator:
             )
 
         # Unity-specific checks
-        if symbol == "U":
+        if symbol == get_config().unity.ticker:
             if price < 15.0 or price > 60.0:
                 raise ValueError(
                     f"Unity price {price} outside historical range [15-60]. "
@@ -115,7 +117,8 @@ class LiveDataValidator:
                 )
 
     @classmethod
-    def validate_volatility(cls, vol: float, symbol: str = "U") -> None:
+    def validate_volatility(cls, vol: float, symbol: str | None = None) -> None:
+        symbol = symbol or get_config().unity.ticker
         """Validate that volatility looks realistic."""
         if vol <= 0 or vol > 5.0:
             raise ValueError(f"Invalid volatility {vol} - must be between 0 and 5.0")
@@ -127,7 +130,7 @@ class LiveDataValidator:
             )
 
         # Unity-specific checks
-        if symbol == "U":
+        if symbol == get_config().unity.ticker:
             if vol < 0.30 or vol > 2.0:
                 logger.warning(f"Unity volatility {vol} outside typical range [0.30-2.0]")
 

--- a/tests/test_databento.py
+++ b/tests/test_databento.py
@@ -8,6 +8,9 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from src.unity_wheel.data_providers.databento.client import DatentoClient
+from src.config.loader import get_config
+
+UNITY = get_config().unity.ticker
 from src.unity_wheel.data_providers.databento.types import (
     DataQuality,
     InstrumentDefinition,
@@ -27,7 +30,7 @@ class TestDatentoTypes:
         raw_data = {
             "instrument_id": 12345,
             "raw_symbol": "U 24 06 21 00055 C",
-            "underlying": "U",
+            "underlying": UNITY,
             "instrument_class": "C",
             "strike_price": 55000,  # In 1/1000ths
             "expiration": "2024-06-21T00:00:00",
@@ -38,7 +41,7 @@ class TestDatentoTypes:
 
         assert defn.instrument_id == 12345
         assert defn.raw_symbol == "U 24 06 21 00055 C"
-        assert defn.underlying == "U"
+        assert defn.underlying == UNITY
         assert defn.option_type == OptionType.CALL
         assert defn.strike_price == Decimal("55")
         assert defn.multiplier == 100
@@ -100,7 +103,7 @@ class TestDataValidator:
         for i in range(5):  # Monday through Friday
             chains.append(
                 OptionChain(
-                    underlying="U",
+                    underlying=UNITY,
                     expiration=datetime(2024, 6, 21),
                     spot_price=Decimal("50"),
                     timestamp=start + timedelta(days=i),
@@ -133,7 +136,7 @@ class TestDataValidator:
         validator = DataValidator()
 
         chain = OptionChain(
-            underlying="U",
+            underlying=UNITY,
             expiration=datetime.now() + timedelta(days=45),
             spot_price=Decimal("50"),
             timestamp=datetime.now(),
@@ -186,7 +189,7 @@ class TestDataValidator:
         validator = DataValidator()
 
         chain = OptionChain(
-            underlying="U",
+            underlying=UNITY,
             expiration=datetime.now() + timedelta(days=45),
             spot_price=Decimal("50"),
             timestamp=datetime.now(),
@@ -199,7 +202,7 @@ class TestDataValidator:
             InstrumentDefinition(
                 instrument_id=1,
                 raw_symbol="U 24 06 21 00050 C",
-                underlying="U",
+                underlying=UNITY,
                 option_type=OptionType.CALL,
                 strike_price=Decimal("50"),
                 expiration=chain.expiration,
@@ -207,7 +210,7 @@ class TestDataValidator:
             InstrumentDefinition(
                 instrument_id=2,
                 raw_symbol="U 24 06 21 00050 P",
-                underlying="U",
+                underlying=UNITY,
                 option_type=OptionType.PUT,
                 strike_price=Decimal("50"),
                 expiration=chain.expiration,
@@ -289,7 +292,7 @@ class TestDatabentoClient:
         chain_time = base_time - timedelta(seconds=30)
 
         chain = OptionChain(
-            underlying="U",
+            underlying=UNITY,
             expiration=base_time + timedelta(days=45),
             spot_price=Decimal("50"),
             timestamp=chain_time,
@@ -324,7 +327,7 @@ class TestDatabentoClient:
             quality = await client.validate_data_quality(chain)
 
         assert isinstance(quality, DataQuality)
-        assert quality.symbol == "U"
+        assert quality.symbol == UNITY
         assert not quality.bid_ask_spread_ok  # Has wide spreads
         assert not quality.sufficient_liquidity  # Has low sizes
         assert quality.data_staleness_seconds == pytest.approx(30, abs=5)

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -6,6 +6,9 @@ import pytest
 
 from src.unity_wheel.models.position import Position
 from src.unity_wheel.strategy.wheel import WheelStrategy
+from src.config.loader import get_config
+
+UNITY = get_config().unity.ticker
 
 
 class TestWheelStrategy:
@@ -73,7 +76,7 @@ class TestWheelStrategy:
         """Test position sizing calculation."""
         # With 20% max allocation and $100k portfolio
         size = wheel.calculate_position_size(
-            symbol="U",
+            symbol=UNITY,
             current_price=35,
             portfolio_value=100000,
         )
@@ -83,7 +86,7 @@ class TestWheelStrategy:
 
         # Test with larger portfolio
         size = wheel.calculate_position_size(
-            symbol="U",
+            symbol=UNITY,
             current_price=35,
             portfolio_value=1000000,
         )
@@ -93,7 +96,7 @@ class TestWheelStrategy:
     def test_should_roll_position_expiry(self, wheel):
         """Test rolling decision based on expiry."""
         position = Position(
-            symbol="U",
+            symbol=UNITY,
             qty=-1,
             avg_price=2.50,
             option_type="put",
@@ -112,7 +115,7 @@ class TestWheelStrategy:
     def test_should_roll_position_deep_itm_put(self, wheel):
         """Test rolling deep ITM put."""
         position = Position(
-            symbol="U",
+            symbol=UNITY,
             qty=-1,
             avg_price=2.50,
             option_type="put",
@@ -131,7 +134,7 @@ class TestWheelStrategy:
     def test_should_roll_position_deep_itm_call(self, wheel):
         """Test rolling deep ITM call."""
         position = Position(
-            symbol="U",
+            symbol=UNITY,
             qty=-1,
             avg_price=2.50,
             option_type="call",
@@ -150,7 +153,7 @@ class TestWheelStrategy:
     def test_should_not_roll_position(self, wheel):
         """Test when position should not be rolled."""
         position = Position(
-            symbol="U",
+            symbol=UNITY,
             qty=-1,
             avg_price=2.50,
             option_type="put",
@@ -169,14 +172,14 @@ class TestWheelStrategy:
     def test_track_position(self, wheel):
         """Test position tracking."""
         # First access creates new position
-        pos = wheel.track_position("U")
+        pos = wheel.track_position(UNITY)
         assert isinstance(pos, WheelPosition)
-        assert pos.symbol == "U"
+        assert pos.symbol == UNITY
         assert pos.shares is None
         assert len(pos.cash_secured_puts) == 0
 
         # Second access returns same position
-        pos2 = wheel.track_position("U")
+        pos2 = wheel.track_position(UNITY)
         assert pos2 is pos
 
         # Different symbol creates different position

--- a/verify_database_integrity.py
+++ b/verify_database_integrity.py
@@ -109,7 +109,8 @@ try:
         ).fetchone()
         if fred_count[0] > 0:
             print(
-                f"\n   Found {fred_count[0]:,} FRED records across {fred_count[1]} series in economic_data table"
+                f"\n   Found {fred_count[0]:,} FRED records across "
+                f"{fred_count[1]} series in economic_data table"
             )
 
 except Exception as e:


### PR DESCRIPTION
## Summary
- use `get_config().unity.ticker` instead of the hard coded `"U"`
- adjust validation helpers and Databento client
- expose ticker in some tests
- fix various style issues found by ruff

## Testing
- `ruff check --select F,E,I .`
- `pytest tests/test_wheel.py -k track_position -vv` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848607b4cfc8330ad3d69c7dcd8fd0f