### PR TITLE
Set pytest coverage threshold to 90

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ ensure_newline_before_comments = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
-addopts = "-v"
+addopts = "-v --cov=src/unity_wheel --cov-report=term --cov-fail-under=90"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.mypy]


### PR DESCRIPTION
## Summary
- enforce 90% test coverage

## Testing
- `ruff check --select F,E,I . | head -n 3`
- `pytest -q` *(fails: unrecognized arguments --cov because pytest-cov is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684821e39b488330a1bab1452661b51b