### PR TITLE
Improve exception handling and add tests

### DIFF
--- a/clean_database.py
+++ b/clean_database.py
@@ -27,8 +27,8 @@ for table in empty_tables:
         if count == 0:
             print(f"   Dropping empty table: {table}")
             conn.execute(f"DROP TABLE IF EXISTS {table}")
-    except:
-        pass
+    except duckdb.Error as exc:
+        print(f"   Failed checking {table}: {exc}")
 
 # Fix inverted spreads in options data
 print("\n🔧 FIXING INVERTED SPREADS:")

--- a/src/unity_wheel/data_providers/base/validation.py
+++ b/src/unity_wheel/data_providers/base/validation.py
@@ -329,7 +329,10 @@ class MarketDataValidator:
         if isinstance(timestamp, str):
             try:
                 timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-            except:
+            except ValueError as exc:
+                logger.warning(
+                    "Invalid timestamp format: %s", timestamp, exc_info=exc
+                )
                 return False
 
         if not isinstance(timestamp, datetime):

--- a/src/unity_wheel/data_providers/base/validation.py
+++ b/src/unity_wheel/data_providers/base/validation.py
@@ -6,9 +6,7 @@ import statistics
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple
-
-import numpy as np
+from typing import Any, Dict, List, Optional, Tuple
 
 from src.unity_wheel.utils import StructuredLogger, get_logger
 
@@ -289,7 +287,7 @@ class MarketDataValidator:
         # Log validation results
         if is_valid:
             logger.info(
-                f"Data validation passed",
+                "Data validation passed",
                 extra={
                     "function": "validate",
                     "quality_level": quality_level.value,
@@ -300,7 +298,7 @@ class MarketDataValidator:
             )
         else:
             logger.warning(
-                f"Data validation failed",
+                "Data validation failed",
                 extra={
                     "function": "validate",
                     "quality_level": quality_level.value,
@@ -330,9 +328,7 @@ class MarketDataValidator:
             try:
                 timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
             except ValueError as exc:
-                logger.warning(
-                    "Invalid timestamp format: %s", timestamp, exc_info=exc
-                )
+                logger.warning("Invalid timestamp format: %s", timestamp, exc_info=exc)
                 return False
 
         if not isinstance(timestamp, datetime):

--- a/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
+++ b/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
@@ -4,14 +4,13 @@
 import os
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Dict, Tuple
-
-from src.unity_wheel.utils.logging import get_logger
 
 import duckdb
 
 from src.config.loader import get_config
+from src.unity_wheel.utils.logging import get_logger
 
 # Get Unity ticker once
 _config = get_config()

--- a/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
+++ b/src/unity_wheel/monitoring/scripts/data_quality_monitor.py
@@ -7,6 +7,8 @@ import time
 from datetime import datetime, timedelta
 from typing import Dict, Tuple
 
+from src.unity_wheel.utils.logging import get_logger
+
 import duckdb
 
 from src.config.loader import get_config
@@ -14,6 +16,8 @@ from src.config.loader import get_config
 # Get Unity ticker once
 _config = get_config()
 UNITY_TICKER = _config.unity.ticker
+
+logger = get_logger(__name__)
 
 
 # Colors for terminal output
@@ -69,7 +73,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
                 "records": result[2],
                 "status": "good" if result[1] <= 1 else ("warning" if result[1] <= 7 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed checking unity_prices: %s", exc, exc_info=exc)
         freshness["unity_prices"] = {"status": "error", "records": 0}
 
     # Options data
@@ -99,7 +104,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
             }
         else:
             freshness["options"] = {"status": "error", "records": 0}
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed checking options data: %s", exc, exc_info=exc)
         freshness["options"] = {"status": "error", "records": 0}
 
     # FRED data
@@ -120,7 +126,8 @@ def check_data_freshness(conn) -> Dict[str, Dict]:
                 "series_count": result[2],
                 "status": "good" if result[1] <= 7 else ("warning" if result[1] <= 30 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed checking FRED data: %s", exc, exc_info=exc)
         freshness["fred"] = {"status": "error", "series_count": 0}
 
     return freshness
@@ -150,7 +157,8 @@ def check_data_quality(conn) -> Dict[str, any]:
             "large": gaps[1],
             "status": "good" if gaps[1] == 0 else ("warning" if gaps[1] < 5 else "error"),
         }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed checking price gaps: %s", exc, exc_info=exc)
         quality["price_gaps"] = {"status": "error"}
 
     # Check Unity volatility
@@ -173,7 +181,8 @@ def check_data_quality(conn) -> Dict[str, any]:
                 "max_daily_move": vol[1] * 100,
                 "status": "good" if vol[0] < 1.0 else ("warning" if vol[0] < 1.5 else "error"),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed checking volatility: %s", exc, exc_info=exc)
         quality["volatility"] = {"status": "error"}
 
     # Check options bid-ask spreads
@@ -201,7 +210,8 @@ def check_data_quality(conn) -> Dict[str, any]:
                     "good" if spreads[0] < 0.1 else ("warning" if spreads[0] < 0.3 else "error")
                 ),
             }
-    except:
+    except duckdb.Error as exc:
+        logger.error("Failed checking spreads: %s", exc, exc_info=exc)
         quality["spreads"] = {"status": "none"}
 
     return quality

--- a/src/unity_wheel/risk/pure_borrowing_analyzer.py
+++ b/src/unity_wheel/risk/pure_borrowing_analyzer.py
@@ -6,7 +6,6 @@ decisions in a tax-free environment.
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
@@ -263,7 +262,7 @@ class PureBorrowingAnalyzer:
             return 0
 
         highest_rate_loan = max(
-            self.loans.values(), key=lambda l: l.annual_rate if l.principal > 0 else 0
+            self.loans.values(), key=lambda loan: loan.annual_rate if loan.principal > 0 else 0
         )
 
         if highest_rate_loan.principal > 0:

--- a/src/unity_wheel/risk/pure_borrowing_analyzer.py
+++ b/src/unity_wheel/risk/pure_borrowing_analyzer.py
@@ -138,7 +138,8 @@ class PureBorrowingAnalyzer:
             # Search between -50% and 500% annual return
             daily_irr = brentq(npv_at_rate, -0.5, 5.0, maxiter=100)
             return daily_irr
-        except:
+        except (ValueError, RuntimeError) as exc:
+            logger.warning("IRR calculation failed: %s", exc, exc_info=exc)
             return None
 
     def analyze_investment(

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -1,0 +1,34 @@
+import logging
+import duckdb
+import pytest
+
+from src.unity_wheel.data_providers.base.validation import MarketDataValidator
+from src.unity_wheel.monitoring.scripts import data_quality_monitor as dq
+from src.unity_wheel.risk.pure_borrowing_analyzer import PureBorrowingAnalyzer
+
+
+def test_check_freshness_invalid_timestamp_logs(caplog):
+    validator = MarketDataValidator()
+    caplog.set_level(logging.WARNING)
+    assert not validator._check_freshness("bad", 5)
+    assert any("Invalid timestamp format" in r.getMessage() for r in caplog.records)
+
+
+class BadConn:
+    def execute(self, *args, **kwargs):
+        raise duckdb.Error("boom")
+
+
+def test_data_quality_monitor_fallback_on_error(caplog):
+    caplog.set_level(logging.ERROR)
+    result = dq.check_data_freshness(BadConn())
+    assert result["unity_prices"]["status"] == "error"
+    assert any("Failed checking unity_prices" in r.getMessage() for r in caplog.records)
+
+
+def test_calculate_irr_failure_logs(caplog):
+    analyzer = PureBorrowingAnalyzer()
+    caplog.set_level(logging.WARNING)
+    cash_flows = [(0, -1000), (1, -50)]
+    assert analyzer.calculate_irr(cash_flows) is None
+    assert any("IRR calculation failed" in r.getMessage() for r in caplog.records)

--- a/tools/debug/debug_databento.py
+++ b/tools/debug/debug_databento.py
@@ -9,7 +9,9 @@ from datetime import datetime, timedelta, timezone
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from src.unity_wheel.databento import DatabentoClient
-from src.unity_wheel.utils import setup_structured_logging
+from src.unity_wheel.utils import get_logger, setup_structured_logging
+
+logger = get_logger(__name__)
 
 
 async def debug_databento():
@@ -114,8 +116,8 @@ async def debug_databento():
         try:
             # This would require admin API access
             print("   Note: Full dataset listing requires admin access")
-        except:
-            pass
+        except Exception as exc:
+            logger.error("Dataset listing failed: %s", exc, exc_info=exc)
 
     finally:
         await client.close()

--- a/tools/fill_unity_options.py
+++ b/tools/fill_unity_options.py
@@ -8,6 +8,9 @@ import sys
 from datetime import datetime, timedelta
 
 import duckdb
+from src.unity_wheel.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -157,8 +160,8 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass  # Skip if already exists
+                except duckdb.Error as exc:
+                    logger.warning("Duplicate option skipped: %s", exc, exc_info=exc)
 
         if options_added % 100 == 0:
             print(f"\r   Added {options_added:,} options...", end="")
@@ -241,8 +244,8 @@ def main():
                         ],
                     )
                     options_added += 1
-                except:
-                    pass
+                except duckdb.Error as exc:
+                    logger.warning("Duplicate option skipped: %s", exc, exc_info=exc)
 
     conn.commit()
 

--- a/tools/generate_missing_unity_options.py
+++ b/tools/generate_missing_unity_options.py
@@ -8,6 +8,9 @@ import sys
 from datetime import datetime, timedelta
 
 import duckdb
+from src.unity_wheel.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 # Add project root to path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -228,8 +231,8 @@ def main():
                     )
                     inserted += 1
                     options_added += 1
-                except:
-                    pass  # Skip duplicates
+                except duckdb.Error as exc:
+                    logger.warning("Duplicate option skipped: %s", exc, exc_info=exc)
 
             if inserted > 0:
                 print(f"   Added {inserted} options for {expiration} expiration")


### PR DESCRIPTION
## Summary
- add logging to debug_databento utilities
- log database cleanup issues
- validate timestamp parsing errors
- record DB query failures in data quality monitor
- warn on failed IRR calculations
- propagate duplicate option warnings in tools
- test the new logging-based error paths

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6848666dab94833099dff3816046c8e3