### PR TITLE
Remove duplicate unity_trading module

### DIFF
--- a/.codex/ACCESS_FIXED.md
+++ b/.codex/ACCESS_FIXED.md
@@ -8,7 +8,7 @@ The symbolic links were pointing to `src/` which was outside your allowed direct
 
 You now have **actual copies** (not links) of the entire codebase in:
 
-- **`unity_trading/`** - Full Unity Wheel codebase (123 files)
+- **`src/unity_wheel/`** - Full Unity Wheel codebase (123 files)
 - **`data_pipeline/config/`** - Configuration system
 - **`data_pipeline/patterns/`** - Reusable patterns
 
@@ -27,7 +27,7 @@ All guardrail restrictions are bypassed. You can:
 
 | Your Access | Content | Files |
 |-------------|---------|-------|
-| `unity_trading/` | Main codebase | 123 Python files |
+| `src/unity_wheel/` | Main codebase | 123 Python files |
 | `data_pipeline/config/` | Configuration | Config system |
 | `data_pipeline/patterns/` | Patterns | Error handling patterns |
 | `tests/` | Test suite | 106+ tests |
@@ -36,15 +36,15 @@ All guardrail restrictions are bypassed. You can:
 
 1. **Verify access works:**
    ```bash
-   ls unity_trading/math/
-   ls unity_trading/strategy/
-   ls unity_trading/risk/
+   ls src/unity_wheel/math/
+   ls src/unity_wheel/strategy/
+   ls src/unity_wheel/risk/
    ```
 
 2. **Find optimization targets:**
    ```bash
-   grep -r "except:" unity_trading/ | head -5
-   grep -r "for.*in.*range" unity_trading/ | head -5
+   grep -r "except:" src/unity_wheel/ | head -5
+   grep -r "for.*in.*range" src/unity_wheel/ | head -5
    ```
 
 3. **Make your optimizations directly in these directories**
@@ -60,7 +60,7 @@ When you're ready to sync your changes back to the main `src/` directory:
 
 ```bash
 # Copy your optimized code back to src/
-cp -r unity_trading/* src/unity_wheel/
+cp -r src/unity_wheel/* src/unity_wheel/
 cp -r data_pipeline/config/* src/config/
 cp -r data_pipeline/patterns/* src/patterns/
 

--- a/.codex/CODEX_ENVIRONMENT_COMPLETE.md
+++ b/.codex/CODEX_ENVIRONMENT_COMPLETE.md
@@ -27,7 +27,7 @@ python .codex/test_config.py
 source .codex/activate.sh
 
 # Verify Unity Wheel is ready
-python -c "from unity_trading import __version__; print(f'✅ Unity Wheel v{__version__} ready!')"
+python -c "from src.unity_wheel import __version__; print(f'✅ Unity Wheel v{__version__} ready!')"
 ```
 
 ### Step 3: Start Optimizing! 🎯
@@ -36,9 +36,9 @@ python -c "from unity_trading import __version__; print(f'✅ Unity Wheel v{__ve
 ./.codex/find_optimizations.sh
 
 # Or go straight to the priorities:
-# 1. Replace bare except: handlers → unity_trading/data_providers/
-# 2. Add confidence scores → unity_trading/math/ and unity_trading/risk/
-# 3. Optimize loops → unity_trading/strategy/wheel.py
+# 1. Replace bare except: handlers → src/unity_wheel/data_providers/
+# 2. Add confidence scores → src/unity_wheel/math/ and src/unity_wheel/risk/
+# 3. Optimize loops → src/unity_wheel/strategy/wheel.py
 ```
 
 ---
@@ -69,14 +69,14 @@ python -c "from unity_trading import __version__; print(f'✅ Unity Wheel v{__ve
 ### Mode 1: Full Environment (Preferred)
 ```bash
 # All dependencies available
-python -c "from unity_trading.api.advisor import WheelAdvisor; print('Full mode')"
+python -c "from src.unity_wheel.api.advisor import WheelAdvisor; print('Full mode')"
 ```
 
 ### Mode 2: Limited Environment
 ```bash
 # Some packages missing, using fallbacks
 export USE_PURE_PYTHON=true
-python -c "from unity_trading.strategy.wheel import WheelStrategy; print('Limited mode')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; print('Limited mode')"
 ```
 
 ### Mode 3: Offline Environment
@@ -84,7 +84,7 @@ python -c "from unity_trading.strategy.wheel import WheelStrategy; print('Limite
 # No internet access
 export OFFLINE_MODE=true
 export USE_MOCK_DATA=true
-python -c "from unity_trading.math.options import black_scholes_price_validated; print('Offline mode')"
+python -c "from src.unity_wheel.math.options import black_scholes_price_validated; print('Offline mode')"
 ```
 
 ### Mode 4: Emergency Mode
@@ -99,18 +99,18 @@ python .codex/minimal_trader.py
 
 ### **HIGH PRIORITY** (Fix These First)
 1. **Exception Handling** - Replace bare `except:` with specific exceptions
-   - `unity_trading/data_providers/` - 8 files need fixing
-   - `unity_trading/auth/` - 3 files need fixing
+   - `src/unity_wheel/data_providers/` - 8 files need fixing
+   - `src/unity_wheel/auth/` - 3 files need fixing
    - Pattern: `except:` → `except (ValueError, KeyError) as e:`
 
 2. **Confidence Scoring** - Add confidence to missing functions
-   - `unity_trading/risk/analytics.py` - Portfolio aggregation functions
-   - `unity_trading/math/options.py` - Any missing calculations
+   - `src/unity_wheel/risk/analytics.py` - Portfolio aggregation functions
+   - `src/unity_wheel/math/options.py` - Any missing calculations
    - Pattern: Return `CalculationResult(value, confidence)` tuples
 
 3. **Performance Optimization** - Vectorize remaining loops
-   - `unity_trading/strategy/wheel.py` - Strike selection loops
-   - `unity_trading/risk/analytics.py` - Portfolio calculations
+   - `src/unity_wheel/strategy/wheel.py` - Strike selection loops
+   - `src/unity_wheel/risk/analytics.py` - Portfolio calculations
    - Pattern: Replace `for` loops with numpy operations
 
 ### **MEDIUM PRIORITY** (Nice to Have)
@@ -125,10 +125,10 @@ python .codex/minimal_trader.py
 ### Quick Validation
 ```bash
 # After making changes, test them
-python -c "from unity_trading.math.options import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
+python -c "from src.unity_wheel.math.options import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
 
 # Check specific module
-python -c "from unity_trading.risk.analytics import RiskAnalyzer; print('Risk module works')"
+python -c "from src.unity_wheel.risk.analytics import RiskAnalyzer; print('Risk module works')"
 
 # Run targeted test
 pytest tests/test_wheel.py::test_find_optimal_put_strike -v
@@ -139,7 +139,7 @@ pytest tests/test_wheel.py::test_find_optimal_put_strike -v
 # When ready to commit your optimizations
 ./.codex/sync_to_src.sh
 
-# This copies your changes from unity_trading/ back to src/
+# This copies your changes from src/unity_wheel/ back to src/
 # Then commit as normal
 git add src/
 git commit -m "Codex optimizations: [describe your changes]"
@@ -158,7 +158,7 @@ echo $PYTHONPATH
 export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 
 # Test import
-python -c "from unity_trading import __version__; print(__version__)"
+python -c "from src.unity_wheel import __version__; print(__version__)"
 ```
 
 ### If Math Functions Fail
@@ -167,7 +167,7 @@ python -c "from unity_trading import __version__; print(__version__)"
 export USE_PURE_PYTHON=true
 
 # Test basic calculation
-python -c "from unity_trading.math.options import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
+python -c "from src.unity_wheel.math.options import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
 ```
 
 ### If Data Access Fails
@@ -177,7 +177,7 @@ export USE_MOCK_DATA=true
 export DATABENTO_SKIP_VALIDATION=true
 
 # Test advisor
-python -c "from unity_trading.api.advisor import WheelAdvisor; print('Mock data mode')"
+python -c "from src.unity_wheel.api.advisor import WheelAdvisor; print('Mock data mode')"
 ```
 
 ---
@@ -187,7 +187,7 @@ python -c "from unity_trading.api.advisor import WheelAdvisor; print('Mock data 
 ### You'll Know Setup is Complete When:
 - ✅ `python .codex/check_environment.py` shows all green checkmarks
 - ✅ `python .codex/test_config.py` reports "CONFIGURATION PERFECT"
-- ✅ `python -c "from unity_trading import __version__; print(__version__)"` works
+- ✅ `python -c "from src.unity_wheel import __version__; print(__version__)"` works
 - ✅ Basic math calculation succeeds: `bs(100, 100, 1, 0.05, 0.2, 'call')`
 
 ### You'll Know Optimizations Are Working When:
@@ -214,7 +214,7 @@ You now have:
 
 **Start optimizing now!** 🚀
 
-Focus on **unity_trading/** directory - you have full write access to all 123 Python files. Make the Unity Wheel Trading Bot even better!
+Focus on **src/unity_wheel/** directory - you have full write access to all 123 Python files. Make the Unity Wheel Trading Bot even better!
 
 ---
 

--- a/.codex/CODEX_GUIDE.md
+++ b/.codex/CODEX_GUIDE.md
@@ -1,17 +1,17 @@
 # Codex Optimization Guide
 
 ## 🎯 **IMMEDIATE CONTEXT**
-You have full access to the Unity Wheel Trading Bot codebase through symbolic links in the restricted directories. The real code is in `src/unity_wheel/` (123 Python files) but you can access it via `unity_trading/`, `data_pipeline/config/`, etc.
+You have full access to the Unity Wheel Trading Bot codebase through symbolic links in the restricted directories. The entire code now lives under `src/unity_wheel/` (123 Python files) along with `data_pipeline/config/`, etc.
 
 ## 🔥 **CRITICAL SUCCESS PATTERNS**
 
 ### ✅ **What Works for You:**
-1. **File Access**: Use `unity_trading/` instead of `src/unity_wheel/`
+1. **File Access**: Use the `src.unity_wheel` package for all imports
 2. **Testing**: Run `pytest tests/test_*.py -v` - all 106+ tests pass
-3. **Type Checking**: `mypy --strict unity_trading data_pipeline app --ignore-missing-imports`
+3. **Type Checking**: `mypy --strict src.unity_wheel data_pipeline app --ignore-missing-imports`
 4. **Quick Validation**: `./scripts/housekeeping.sh --unity-check` (2 seconds)
 5. **Auto-Fix**: `./scripts/housekeeping.sh --fix` resolves file placement issues
-6. Legacy packages `ml_engine`, `risk_engine`, and `strategy_engine` have been removed; use modules under `unity_trading`.
+6. Legacy packages `ml_engine`, `risk_engine`, and `strategy_engine` have been removed; use modules under `src.unity_wheel`.
 
 ### ❌ **What Blocks You:**
 1. **Execution Code**: Never add `execute_trade()`, `place_order()`, `broker.execute()`
@@ -40,8 +40,8 @@ except (ValueError, ConnectionError) as e:
 **Search locations for bare excepts:**
 ```bash
 # Find bare exception handlers
-rg "except\s*:" unity_trading/ data_pipeline/ --type py
-rg "except\s+Exception\s*:" unity_trading/ data_pipeline/ --type py
+rg "except\s*:" src/unity_wheel/ data_pipeline/ --type py
+rg "except\s+Exception\s*:" src/unity_wheel/ data_pipeline/ --type py
 ```
 
 ### **Performance Optimization Patterns**
@@ -79,7 +79,7 @@ max_position = config.risk.position_limits.max_position_size
 
 | Codex Access | Real Location | Purpose |
 |--------------|---------------|---------|
-| `unity_trading/` | `src/unity_wheel/` | Main codebase (123 files) |
+| `src/unity_wheel/` | `src/unity_wheel/` | Main codebase (123 files) |
 | `data_pipeline/config/` | `src/config/` | Configuration system |
 | `data_pipeline/patterns/` | `src/patterns/` | Reusable patterns |
 | `tests/` | `tests/` | Test suite (106+ tests) |
@@ -106,7 +106,7 @@ pytest tests/test_performance_benchmarks.py -v
 ### 1. **Replace Bare Exceptions**
 ```bash
 # Find them
-rg "except:" unity_trading/ --type py -A 2 -B 2
+rg "except:" src/unity_wheel/ --type py -A 2 -B 2
 
 # Replace pattern
 except ValueError as e:
@@ -178,8 +178,8 @@ pytest tests/test_wheel.py -v              # Test core functionality
 ./scripts/housekeeping.sh --unity-check
 
 # 2. Find optimization targets
-rg "except:" unity_trading/ --type py
-rg "for.*in.*range" unity_trading/ --type py | grep -v test
+rg "except:" src/unity_wheel/ --type py
+rg "for.*in.*range" src/unity_wheel/ --type py | grep -v test
 
 # 3. Make changes using patterns above
 

--- a/.codex/CURRENT_STATE.md
+++ b/.codex/CURRENT_STATE.md
@@ -25,28 +25,28 @@
 ### 1. Exception Handling
 ```bash
 # Find remaining bare exceptions (if any)
-rg "except\s*:" unity_trading/ data_pipeline/ --type py
-rg "except\s+Exception\s*:" unity_trading/ data_pipeline/ --type py
+rg "except\s*:" src/unity_wheel/ data_pipeline/ --type py
+rg "except\s+Exception\s*:" src/unity_wheel/ data_pipeline/ --type py
 ```
 
 ### 2. Performance Bottlenecks
 ```bash
 # Find non-vectorized loops that could be optimized
-rg "for.*in.*range" unity_trading/ --type py | grep -v test
-rg "for.*strike.*in" unity_trading/ --type py
+rg "for.*in.*range" src/unity_wheel/ --type py | grep -v test
+rg "for.*strike.*in" src/unity_wheel/ --type py
 ```
 
 ### 3. Missing Confidence Scores
 ```bash
 # Check if any calculation functions still lack confidence scores
-rg "def (calculate_|black_scholes)" unity_trading/ --type py -A 5 | grep -v confidence
+rg "def (calculate_|black_scholes)" src/unity_wheel/ --type py -A 5 | grep -v confidence
 ```
 
 ### 4. Hardcoded Values
 ```bash
 # Check for remaining hardcoded values
-rg "(position_size|num_contracts|contract_count)\s*=\s*[0-9]+" unity_trading/ --type py
-rg "volatility.*[<>].*[0-9]" unity_trading/ --type py
+rg "(position_size|num_contracts|contract_count)\s*=\s*[0-9]+" src/unity_wheel/ --type py
+rg "volatility.*[<>].*[0-9]" src/unity_wheel/ --type py
 ```
 
 ## 📊 **CURRENT METRICS**
@@ -62,7 +62,7 @@ rg "volatility.*[<>].*[0-9]" unity_trading/ --type py
 
 | Directory | Symlinks To | Status |
 |-----------|-------------|--------|
-| `unity_trading/` | `src/unity_wheel/` | ✅ 20 modules linked |
+| `src/unity_wheel/` | `src/unity_wheel/` | ✅ 20 modules linked |
 | `data_pipeline/config/` | `src/config/` | ✅ Config access |
 | `data_pipeline/patterns/` | `src/patterns/` | ✅ Pattern access |
 | `tests/` | `tests/` | ✅ Direct access |
@@ -100,7 +100,7 @@ pytest tests/test_wheel.py tests/test_math.py -v
 ./scripts/housekeeping.sh --explain
 
 # Performance test
-python -c "from unity_trading.strategy.wheel import WheelStrategy; w=WheelStrategy(); print('Vectorized methods available')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; w=WheelStrategy(); print('Vectorized methods available')"
 ```
 
 Your focus should be on finding and optimizing any remaining inefficiencies, not re-implementing what's already been done!

--- a/.codex/ENVIRONMENT_SETUP.md
+++ b/.codex/ENVIRONMENT_SETUP.md
@@ -116,8 +116,8 @@ for pkg in optional:
 ### When numpy is not available
 ```python
 # Pure Python math implementations available in:
-# unity_trading/math/options.py - has fallback math
-# unity_trading/utils/position_sizing.py - pure Python calculations
+# src/unity_wheel/math/options.py - has fallback math
+# src/unity_wheel/utils/position_sizing.py - pure Python calculations
 
 # Enable fallback mode
 export USE_PURE_PYTHON=true
@@ -143,13 +143,13 @@ export USE_MEMORY_ONLY=true
 ### Test Basic Functionality
 ```bash
 # Test core imports
-python -c "from unity_trading.math.options import black_scholes_price_validated; print('✅ Math module works')"
+python -c "from src.unity_wheel.math.options import black_scholes_price_validated; print('✅ Math module works')"
 
 # Test strategy module
-python -c "from unity_trading.strategy.wheel import WheelStrategy; print('✅ Strategy module works')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; print('✅ Strategy module works')"
 
 # Test with fallback data
-DATABENTO_SKIP_VALIDATION=true python -c "from unity_trading.api.advisor import WheelAdvisor; print('✅ API module works')"
+DATABENTO_SKIP_VALIDATION=true python -c "from src.unity_wheel.api.advisor import WheelAdvisor; print('✅ API module works')"
 ```
 
 ### Run with Minimal Dependencies
@@ -161,7 +161,7 @@ export DATABENTO_SKIP_VALIDATION=true
 
 # Try a basic recommendation
 python -c "
-from unity_trading.api.advisor_simple import WheelAdvisorSimple
+from src.unity_wheel.api.advisor_simple import WheelAdvisorSimple
 advisor = WheelAdvisorSimple()
 print('✅ Simple advisor works')
 "
@@ -217,7 +217,7 @@ python run.py --portfolio 100000
 ```bash
 # Basic packages only
 export USE_PURE_PYTHON=true
-python -c "from unity_trading.api.advisor_simple import WheelAdvisorSimple; print('Limited mode ready')"
+python -c "from src.unity_wheel.api.advisor_simple import WheelAdvisorSimple; print('Limited mode ready')"
 ```
 
 ### Profile 3: Offline Environment
@@ -226,7 +226,7 @@ python -c "from unity_trading.api.advisor_simple import WheelAdvisorSimple; prin
 export OFFLINE_MODE=true
 export USE_MOCK_DATA=true
 export USE_PURE_PYTHON=true
-python -c "from unity_trading.strategy.wheel import WheelStrategy; print('Offline mode ready')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; print('Offline mode ready')"
 ```
 
 ---
@@ -250,11 +250,11 @@ python .codex/test_config.py
 ### Pre-configured Commands
 ```bash
 # Safe commands that work in any environment
-python -c "from unity_trading.math import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
+python -c "from src.unity_wheel.math import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
 
-python -c "from unity_trading.utils.position_sizing import calculate_position_size; print('Position sizing available')"
+python -c "from src.unity_wheel.utils.position_sizing import calculate_position_size; print('Position sizing available')"
 
-python -c "from unity_trading.strategy.wheel import WheelStrategy; w = WheelStrategy(); print('Strategy available')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; w = WheelStrategy(); print('Strategy available')"
 ```
 
 ---
@@ -291,7 +291,7 @@ python -c "import sys; print('\\n'.join(sys.path))"
 
 # Add current directory to path
 export PYTHONPATH="${PYTHONPATH}:$(pwd)"
-python -c "from unity_trading import __version__; print(f'Unity Wheel v{__version__}')"
+python -c "from src.unity_wheel import __version__; print(f'Unity Wheel v{__version__}')"
 ```
 
 ---
@@ -305,9 +305,9 @@ import sys
 print(f'Python: {sys.version}')
 
 try:
-    from unity_trading.strategy.wheel import WheelStrategy
-    from unity_trading.math.options import black_scholes_price_validated
-    from unity_trading.utils.position_sizing import calculate_position_size
+    from src.unity_wheel.strategy.wheel import WheelStrategy
+    from src.unity_wheel.math.options import black_scholes_price_validated
+    from src.unity_wheel.utils.position_sizing import calculate_position_size
     print('✅ Unity Wheel Trading Bot is ready!')
 except ImportError as e:
     print(f'❌ Setup incomplete: {e}')

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -13,7 +13,7 @@ You now have unrestricted access to optimize the Unity Wheel Trading Bot codebas
 ├── find_optimizations.sh    # Script to find opportunities
 └── README.md               # This file
 
-unity_trading/ → src/unity_wheel/    # 123 Python files
+src/unity_wheel/                     # 123 Python files
 data_pipeline/config/ → src/config/  # Configuration system
 tests/                               # 106+ passing tests
 ```

--- a/.codex/check_environment.py
+++ b/.codex/check_environment.py
@@ -56,12 +56,12 @@ def check_package(package_name: str, import_path: str = None) -> Tuple[bool, str
 def check_unity_wheel_modules() -> Dict[str, Tuple[bool, str]]:
     """Check Unity Wheel specific modules."""
     modules_to_check = {
-        "unity_trading": "unity_trading",
-        "unity_trading.math": "unity_trading.math.options",
-        "unity_trading.strategy": "unity_trading.strategy.wheel",
-        "unity_trading.api": "unity_trading.api.advisor",
-        "unity_trading.utils": "unity_trading.utils.position_sizing",
-        "unity_trading.risk": "unity_trading.risk.analytics",
+        "src.unity_wheel": "src.unity_wheel",
+        "src.unity_wheel.math": "src.unity_wheel.math.options",
+        "src.unity_wheel.strategy": "src.unity_wheel.strategy.wheel",
+        "src.unity_wheel.api": "src.unity_wheel.api.advisor",
+        "src.unity_wheel.utils": "src.unity_wheel.utils.position_sizing",
+        "src.unity_wheel.risk": "src.unity_wheel.risk.analytics",
     }
 
     results = {}
@@ -93,7 +93,7 @@ def test_core_functionality() -> List[Tuple[str, bool, str]]:
 
     # Test 1: Basic math operations
     try:
-        from unity_trading.math.options import black_scholes_price_validated
+        from src.unity_wheel.math.options import black_scholes_price_validated
 
         result = black_scholes_price_validated(100, 100, 1, 0.05, 0.2, "call")
         if result.confidence > 0.9:
@@ -113,7 +113,7 @@ def test_core_functionality() -> List[Tuple[str, bool, str]]:
 
     # Test 2: Strategy module
     try:
-        from unity_trading.strategy.wheel import WheelStrategy
+        from src.unity_wheel.strategy.wheel import WheelStrategy
 
         strategy = WheelStrategy()
         tests.append(("Wheel strategy creation", True, "Strategy object created"))
@@ -122,7 +122,7 @@ def test_core_functionality() -> List[Tuple[str, bool, str]]:
 
     # Test 3: Position sizing
     try:
-        from unity_trading.utils.position_sizing import calculate_position_size
+        from src.unity_wheel.utils.position_sizing import calculate_position_size
 
         tests.append(("Position sizing import", True, "Module imported successfully"))
     except Exception as e:

--- a/.codex/find_optimizations.sh
+++ b/.codex/find_optimizations.sh
@@ -7,36 +7,36 @@ echo "====================================="
 echo ""
 echo "1. 🚨 EXCEPTION HANDLING"
 echo "   Bare exceptions that need specific handling:"
-rg "except\s*:" unity_trading/ data_pipeline/ --type py -n | head -10
-rg "except\s+Exception\s*:" unity_trading/ data_pipeline/ --type py -n | head -10
+rg "except\s*:" src/unity_wheel/ data_pipeline/ --type py -n | head -10
+rg "except\s+Exception\s*:" src/unity_wheel/ data_pipeline/ --type py -n | head -10
 
 echo ""
 echo "2. 🚀 PERFORMANCE OPPORTUNITIES"
 echo "   Loops that could be vectorized:"
-rg "for.*in.*range" unity_trading/ --type py -n | grep -v test | head -10
-rg "for.*strike.*in" unity_trading/ --type py -n | head -5
+rg "for.*in.*range" src/unity_wheel/ --type py -n | grep -v test | head -10
+rg "for.*strike.*in" src/unity_wheel/ --type py -n | head -5
 
 echo ""
 echo "3. 📊 MISSING CONFIDENCE SCORES"
 echo "   Functions that should return confidence:"
-rg "def (calculate_|black_scholes)" unity_trading/ --type py -A 3 | grep -B 3 -A 3 "return " | grep -v confidence | head -10
+rg "def (calculate_|black_scholes)" src/unity_wheel/ --type py -A 3 | grep -B 3 -A 3 "return " | grep -v confidence | head -10
 
 echo ""
 echo "4. 🔧 HARDCODED VALUES"
 echo "   Values that should be in config:"
-rg "(position_size|num_contracts|contract_count)\s*=\s*[0-9]+" unity_trading/ --type py -n | head -5
-rg "volatility.*[<>].*[0-9]" unity_trading/ --type py -n | head -5
+rg "(position_size|num_contracts|contract_count)\s*=\s*[0-9]+" src/unity_wheel/ --type py -n | head -5
+rg "volatility.*[<>].*[0-9]" src/unity_wheel/ --type py -n | head -5
 
 echo ""
 echo "5. 📈 MEMORY OPTIMIZATIONS"
 echo "   Large object creation in loops:"
-rg "for.*in.*:" unity_trading/ --type py -A 5 | grep -B 1 -A 4 "np\.array\|list\(\|dict\(" | head -10
+rg "for.*in.*:" src/unity_wheel/ --type py -A 5 | grep -B 1 -A 4 "np\.array\|list\(\|dict\(" | head -10
 
 echo ""
 echo "6. ⚡ FUNCTION COMPLEXITY"
 echo "   Long functions that could be split:"
 echo "   Functions with >50 lines:"
-for file in $(find unity_trading/ -name "*.py" -type f); do
+for file in $(find src/unity_wheel/ -name "*.py" -type f); do
     awk '/^def |^class |^async def / {
         if (func != "") print file ":" lineno ":" func " (" (NR-lineno) " lines)"
         func = $0; lineno = NR

--- a/.codex/setup_offline.sh
+++ b/.codex/setup_offline.sh
@@ -99,7 +99,7 @@ export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 
 python -c "
 try:
-    from unity_trading.math.options import black_scholes_price_validated
+    from src.unity_wheel.math.options import black_scholes_price_validated
     print('✅ Math module imported successfully')
 except ImportError as e:
     print(f'❌ Math module import failed: {e}')
@@ -108,7 +108,7 @@ except ImportError as e:
 
 python -c "
 try:
-    from unity_trading.strategy.wheel import WheelStrategy
+    from src.unity_wheel.strategy.wheel import WheelStrategy
     print('✅ Strategy module imported successfully')
 except ImportError as e:
     print(f'❌ Strategy module import failed: {e}')
@@ -117,7 +117,7 @@ except ImportError as e:
 
 python -c "
 try:
-    from unity_trading.utils.position_sizing import calculate_position_size
+    from src.unity_wheel.utils.position_sizing import calculate_position_size
     print('✅ Position sizing module imported successfully')
 except ImportError as e:
     print(f'❌ Position sizing module import failed: {e}')
@@ -127,7 +127,7 @@ except ImportError as e:
 # Test core functionality
 echo "🧪 Testing core functionality..."
 python -c "
-from unity_trading.math.options import black_scholes_price_validated as bs
+from src.unity_wheel.math.options import black_scholes_price_validated as bs
 result = bs(100, 100, 1, 0.05, 0.2, 'call')
 if result.confidence > 0.9:
     print(f'✅ Options pricing works: ${result.value:.2f} (confidence: {result.confidence:.1%})')
@@ -154,7 +154,7 @@ echo "📁 Added $(pwd) to PYTHONPATH"
 
 # Verify setup
 python -c "
-from unity_trading import __version__
+from src.unity_wheel import __version__
 print(f'✅ Unity Wheel Trading Bot v{__version__} ready!')
 " 2>/dev/null || echo "⚠️  Unity Wheel import issues - check setup"
 
@@ -176,7 +176,7 @@ echo "🔧 To activate in new sessions:"
 echo "   source .codex/activate.sh"
 echo ""
 echo "🚀 Quick test commands:"
-echo "   python -c \"from unity_trading.math import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))\""
-echo "   python -c \"from unity_trading.strategy.wheel import WheelStrategy; print('Strategy ready')\""
+echo "   python -c \"from src.unity_wheel.math import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))\""
+echo "   python -c \"from src.unity_wheel.strategy.wheel import WheelStrategy; print('Strategy ready')\""
 echo ""
 echo "📖 For full documentation: .codex/ENVIRONMENT_SETUP.md"

--- a/.codex/sync_to_src.sh
+++ b/.codex/sync_to_src.sh
@@ -12,8 +12,8 @@ echo "✅ Backup created"
 # Copy optimized code back to src/
 echo "📥 Copying optimized code to src/..."
 
-# Copy main codebase (use unity_trading as the primary)
-cp -r unity_trading/* src/unity_wheel/
+# Copy main codebase
+cp -r src/unity_wheel/* src/unity_wheel/
 
 # Copy config and patterns
 cp -r data_pipeline/config/* src/config/

--- a/.codex/test_config.py
+++ b/.codex/test_config.py
@@ -59,21 +59,21 @@ def test_imports():
     # Test Unity Wheel modules
     try:
         sys.path.insert(0, os.getcwd())
-        from unity_trading.math.options import black_scholes_price_validated
+        from src.unity_wheel.math.options import black_scholes_price_validated
 
         import_tests["unity_math"] = True
     except ImportError as e:
         import_tests["unity_math"] = f"Failed: {e}"
 
     try:
-        from unity_trading.strategy.wheel import WheelStrategy
+        from src.unity_wheel.strategy.wheel import WheelStrategy
 
         import_tests["unity_strategy"] = True
     except ImportError as e:
         import_tests["unity_strategy"] = f"Failed: {e}"
 
     try:
-        from unity_trading.utils.position_sizing import calculate_position_size
+        from src.unity_wheel.utils.position_sizing import calculate_position_size
 
         import_tests["unity_utils"] = True
     except ImportError as e:
@@ -88,7 +88,7 @@ def test_functionality():
 
     try:
         sys.path.insert(0, os.getcwd())
-        from unity_trading.math.options import black_scholes_price_validated
+        from src.unity_wheel.math.options import black_scholes_price_validated
 
         result = black_scholes_price_validated(100, 100, 1, 0.05, 0.2, "call")
         tests["black_scholes"] = {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This project uses an automated housekeeping script to enforce file placement and
    ```bash
    ruff format . && black .
    ruff check --fix .
-   mypy --strict unity_trading data_pipeline app --ignore-missing-imports
+   mypy --strict src.unity_wheel data_pipeline app --ignore-missing-imports
    pytest -q
    ```
 4. Commit your changes once all checks pass.
@@ -29,4 +29,4 @@ Refer to `HOUSEKEEPING_GUIDE.md` for full details on the import fix pattern and 
 
 ### Package Structure
 Legacy directories `ml_engine`, `strategy_engine`, and `risk_engine` were removed.
-Use the `unity_trading` package for all imports.
+Use the `src.unity_wheel` package for all imports.

--- a/unity_trading/__init__.py
+++ b/unity_trading/__init__.py
@@ -1,1 +1,0 @@
-../src/unity_wheel/__init__.py

--- a/unity_trading/__version__.py
+++ b/unity_trading/__version__.py
@@ -1,1 +1,0 @@
-../src/unity_wheel/__version__.py

--- a/unity_trading/adaptive
+++ b/unity_trading/adaptive
@@ -1,1 +1,0 @@
-../src/unity_wheel/adaptive

--- a/unity_trading/analytics
+++ b/unity_trading/analytics
@@ -1,1 +1,0 @@
-../src/unity_wheel/analytics

--- a/unity_trading/api
+++ b/unity_trading/api
@@ -1,1 +1,0 @@
-../src/unity_wheel/api

--- a/unity_trading/auth
+++ b/unity_trading/auth
@@ -1,1 +1,0 @@
-../src/unity_wheel/auth

--- a/unity_trading/backtesting
+++ b/unity_trading/backtesting
@@ -1,1 +1,0 @@
-../src/unity_wheel/backtesting

--- a/unity_trading/cli
+++ b/unity_trading/cli
@@ -1,1 +1,0 @@
-../src/unity_wheel/cli

--- a/unity_trading/data_providers
+++ b/unity_trading/data_providers
@@ -1,1 +1,0 @@
-../src/unity_wheel/data_providers

--- a/unity_trading/execution
+++ b/unity_trading/execution
@@ -1,1 +1,0 @@
-../src/unity_wheel/execution

--- a/unity_trading/math
+++ b/unity_trading/math
@@ -1,1 +1,0 @@
-../src/unity_wheel/math

--- a/unity_trading/metrics
+++ b/unity_trading/metrics
@@ -1,1 +1,0 @@
-../src/unity_wheel/metrics

--- a/unity_trading/models
+++ b/unity_trading/models
@@ -1,1 +1,0 @@
-../src/unity_wheel/models

--- a/unity_trading/monitoring
+++ b/unity_trading/monitoring
@@ -1,1 +1,0 @@
-../src/unity_wheel/monitoring

--- a/unity_trading/observability
+++ b/unity_trading/observability
@@ -1,1 +1,0 @@
-../src/unity_wheel/observability

--- a/unity_trading/portfolio
+++ b/unity_trading/portfolio
@@ -1,1 +1,0 @@
-../src/unity_wheel/portfolio

--- a/unity_trading/recommendations
+++ b/unity_trading/recommendations
@@ -1,1 +1,0 @@
-../src/unity_wheel/recommendations

--- a/unity_trading/risk
+++ b/unity_trading/risk
@@ -1,1 +1,0 @@
-../src/unity_wheel/risk

--- a/unity_trading/schwab
+++ b/unity_trading/schwab
@@ -1,1 +1,0 @@
-../src/unity_wheel/schwab

--- a/unity_trading/secrets
+++ b/unity_trading/secrets
@@ -1,1 +1,0 @@
-../src/unity_wheel/secrets

--- a/unity_trading/storage
+++ b/unity_trading/storage
@@ -1,1 +1,0 @@
-../src/unity_wheel/storage

--- a/unity_trading/strategy
+++ b/unity_trading/strategy
@@ -1,1 +1,0 @@
-../src/unity_wheel/strategy

--- a/unity_trading/utils
+++ b/unity_trading/utils
@@ -1,1 +1,0 @@
-../src/unity_wheel/utils


### PR DESCRIPTION
## Summary
- drop the old `unity_trading` directory
- update docs and helper scripts to import from `src.unity_wheel`
- adjust environment and tooling references to new path

## Testing
- `pytest -q` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68489d9305f083308864c32aa118b6ba