### PR TITLE
Add observability metrics tracking

### DIFF
--- a/src/unity_wheel/api/advisor.py
+++ b/src/unity_wheel/api/advisor.py
@@ -567,8 +567,7 @@ class WheelAdvisor:
 
         # Margin requirement
         margin_required = strike * self.constraints.CONTRACTS_PER_TRADE * contracts * 0.20
-
-        return RiskMetrics(
+        metrics = RiskMetrics(
             max_loss=max_loss,
             probability_assignment=probability_itm,
             expected_return=expected_return,
@@ -576,6 +575,8 @@ class WheelAdvisor:
             var_95=position_var,
             margin_required=margin_required,
         )
+        metrics_collector.record_risk_metrics(metrics)
+        return metrics
 
     def _calculate_edge(
         self,

--- a/src/unity_wheel/cli/run.py
+++ b/src/unity_wheel/cli/run.py
@@ -30,6 +30,7 @@ from src.unity_wheel.data_providers.validation import validate_market_data
 from src.unity_wheel.monitoring import get_performance_monitor
 from src.unity_wheel.monitoring.diagnostics import SelfDiagnostics
 from src.unity_wheel.observability import get_observability_exporter
+from src.unity_wheel.metrics import metrics_collector
 from src.unity_wheel.risk import RiskLimits
 from src.unity_wheel.secrets.integration import SecretInjector
 from src.unity_wheel.strategy import WheelParameters
@@ -265,7 +266,22 @@ def main(
     # Show performance metrics if requested
     if performance:
         monitor = get_performance_monitor()
-        print(monitor.generate_report(format=output_format))
+        perf_report = monitor.generate_report(format=output_format)
+        metrics_report = metrics_collector.generate_report()
+        if output_format == "json":
+            print(
+                json.dumps(
+                    {
+                        "performance": json.loads(perf_report),
+                        "decision_metrics": metrics_report,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(perf_report)
+            print("")
+            print(metrics_report)
         return 0
 
     # Export metrics for dashboards if requested

--- a/src/unity_wheel/monitoring/performance.py
+++ b/src/unity_wheel/monitoring/performance.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import numpy as np
 
 from ..utils import get_logger
+from ..metrics import metrics_collector
 
 logger = get_logger(__name__)
 
@@ -451,6 +452,7 @@ def performance_monitored(operation: Optional[str] = None):
             finally:
                 duration_ms = (time.time() - start_time) * 1000
                 monitor.record(op_name, duration_ms, success)
+                metrics_collector.record_function_timing(op_name, duration_ms)
 
         return wrapper
 

--- a/src/unity_wheel/storage/cache/general_cache.py
+++ b/src/unity_wheel/storage/cache/general_cache.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, TypeVar, Union
 
 from src.unity_wheel.utils.logging import get_logger
+from src.unity_wheel.metrics import metrics_collector
 
 logger = get_logger(__name__)
 
@@ -67,14 +68,17 @@ class CacheStatistics:
         self.hits += 1
         self.computation_time_saved_ms += time_saved_ms
         self.entries_by_key[key] = self.entries_by_key.get(key, 0) + 1
+        metrics_collector.record_cache_hit()
 
     def record_miss(self, key: str) -> None:
         """Record cache miss."""
         self.misses += 1
+        metrics_collector.record_cache_miss()
 
     def record_eviction(self, key: str) -> None:
         """Record cache eviction."""
         self.evictions += 1
+        metrics_collector.record_cache_eviction()
 
     def get_summary(self) -> Dict[str, Any]:
         """Get statistics summary."""

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -1,0 +1,68 @@
+import sys
+sys.modules.setdefault("google", type(sys)("google"))
+sys.modules.setdefault("google.cloud", type(sys)("google.cloud"))
+sys.modules.setdefault("google.cloud.storage", type(sys)("google.cloud.storage"))
+sys.modules.setdefault("google.cloud.exceptions", type(sys)("google.cloud.exceptions"))
+sys.modules["google.cloud.exceptions"].NotFound = Exception
+sys.modules.setdefault("databento", type(sys)("databento"))
+import types
+dbn = types.ModuleType("databento_dbn")
+dbn.Schema = object
+dbn.SType = object
+sys.modules.setdefault("databento_dbn", dbn)
+from src.unity_wheel.monitoring import performance_monitored, get_performance_monitor
+from src.unity_wheel.storage.cache.general_cache import cached, invalidate_cache
+from src.unity_wheel.metrics import metrics_collector
+from src.unity_wheel.risk.analytics import RiskMetrics
+
+@performance_monitored("sample_func")
+@cached(ttl=1)
+def _sample(x: int) -> int:
+    return x * 2
+
+
+def test_function_timing_and_cache() -> None:
+    invalidate_cache()
+    metrics_collector.function_timings.clear()
+    metrics_collector.cache_hits = 0
+    metrics_collector.cache_misses = 0
+    _sample(2)
+    _sample(2)
+    stats = metrics_collector.get_function_stats()
+    cache = metrics_collector.get_cache_summary()
+    assert "sample_func" in stats
+    assert stats["sample_func"]["count"] >= 2
+    assert cache["hits"] >= 1
+
+
+def test_risk_metrics_recording() -> None:
+    metrics_collector.risk_history.clear()
+    rm = RiskMetrics(
+        var_95=1.0,
+        var_99=1.5,
+        cvar_95=2.0,
+        cvar_99=2.5,
+        kelly_fraction=0.1,
+        portfolio_delta=10.0,
+        portfolio_gamma=1.0,
+        portfolio_vega=2.0,
+        portfolio_theta=-0.1,
+        margin_requirement=100.0,
+        margin_utilization=0.2,
+    )
+    metrics_collector.record_risk_metrics(rm)
+    dist = metrics_collector.get_risk_distribution()
+    assert dist["var_95"]["avg"] == 1.0
+    assert "margin_requirement" in dist
+
+
+def test_performance_report_generation() -> None:
+    monitor = get_performance_monitor()
+    text_report = monitor.generate_report(format="text")
+    json_report = monitor.generate_report(format="json")
+    assert "PERFORMANCE MONITORING REPORT" in text_report
+    assert "operations_tracked" in json_report
+    metrics_output = metrics_collector.generate_report()
+    assert "DECISION METRICS REPORT" in metrics_output
+
+


### PR DESCRIPTION
## Summary
- extend `metrics_collector` with function timing, cache and risk tracking
- hook cache and performance systems to record metrics
- export new metrics through observability exporter and CLI
- add tests covering metrics capture and export

## Testing
- `python3 -m pytest tests/test_observability_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b2f13e04833086c2822e30277c77