### PR TITLE
Integrate FRED data into CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,18 @@ await storage.cleanup_old_data()
 ### Self-Validating Mathematics
 
 ```python
+import asyncio
 from unity_wheel.math import black_scholes_price_validated
+from src.unity_wheel.data_providers.base import FREDDataManager
+
+# Pull latest risk‑free rate from FRED
+rf_rate, _ = asyncio.run(FREDDataManager().get_or_fetch_risk_free_rate(3))
 
 result = black_scholes_price_validated(
     S=35.50,    # Unity current price
     K=32.50,    # Strike price
     T=0.123,    # 45 days to expiration
-    r=0.05,     # Risk-free rate
+    r=rf_rate,  # FRED risk-free rate
     sigma=0.65, # Implied volatility
     option_type="put"
 )

--- a/src/unity_wheel/cli/databento_integration.py
+++ b/src/unity_wheel/cli/databento_integration.py
@@ -20,12 +20,15 @@ logger = logging.getLogger(__name__)
 async def create_databento_market_snapshot(
     portfolio_value: float,
     ticker: str = "U",
+    *,
+    risk_free_rate: float = 0.05,
 ) -> tuple[MarketSnapshot, float]:
     """Create market snapshot from real Databento data.
 
     Args:
         portfolio_value: Total portfolio value
         ticker: Stock ticker (default: "U" for Unity)
+        risk_free_rate: Risk-free rate to use for IV calculations
 
     Returns:
         MarketSnapshot with real Unity options data
@@ -118,7 +121,7 @@ async def create_databento_market_snapshot(
                 positions=[],
                 option_chain=option_chain,
                 implied_volatility=0.45,  # Unity typical IV
-                risk_free_rate=0.05,
+                risk_free_rate=risk_free_rate,
             )
             # Confidence based on number of option candidates
             confidence = 1.0 if len(option_chain) > 10 else 0.8
@@ -129,7 +132,12 @@ async def create_databento_market_snapshot(
             await client.close()
 
 
-def get_market_data_sync(portfolio_value: float, ticker: str = "U") -> tuple[MarketSnapshot, float]:
+def get_market_data_sync(
+    portfolio_value: float,
+    ticker: str = "U",
+    *,
+    risk_free_rate: float = 0.05,
+) -> tuple[MarketSnapshot, float]:
     """Synchronous wrapper for getting market data.
 
     Args:
@@ -146,6 +154,12 @@ def get_market_data_sync(portfolio_value: float, ticker: str = "U") -> tuple[Mar
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        return loop.run_until_complete(create_databento_market_snapshot(portfolio_value, ticker))
+        return loop.run_until_complete(
+            create_databento_market_snapshot(
+                portfolio_value,
+                ticker,
+                risk_free_rate=risk_free_rate,
+            )
+        )
     finally:
         loop.close()

--- a/src/unity_wheel/cli/run.py
+++ b/src/unity_wheel/cli/run.py
@@ -27,6 +27,8 @@ from src.unity_wheel.api import MarketSnapshot, OptionData, WheelAdvisor
 from src.unity_wheel.data_providers.databento.client import DatabentoClient
 from src.unity_wheel.data_providers.databento.integration import DatabentoIntegration
 from src.unity_wheel.data_providers.validation import validate_market_data
+from src.unity_wheel.data_providers.base import FREDDataManager
+from src.unity_wheel.storage.storage import Storage
 from src.unity_wheel.monitoring import get_performance_monitor
 from src.unity_wheel.monitoring.diagnostics import SelfDiagnostics
 from src.unity_wheel.observability import get_observability_exporter
@@ -79,6 +81,17 @@ def generate_recommendation(
     """Generate wheel strategy recommendation for Unity using real market data."""
     settings = get_settings()
 
+    # Initialize FRED data manager and retrieve risk metrics
+    storage = Storage()
+    asyncio.run(storage.initialize())
+    fred_manager = FREDDataManager(storage=storage)
+    rf_rate, _ = asyncio.run(fred_manager.get_or_fetch_risk_free_rate(3))
+    regime, vix = asyncio.run(fred_manager.get_volatility_regime())
+    logger.info(
+        "Fetched FRED metrics",
+        extra={"risk_free_rate": rf_rate, "volatility_regime": regime, "vix": vix},
+    )
+
     # Create wheel parameters from settings
     wheel_params = WheelParameters(
         target_delta=settings.wheel_delta_target,
@@ -92,6 +105,8 @@ def generate_recommendation(
         max_cvar_95=0.075,
         max_margin_utilization=0.5,
     )
+    # Scale limits based on volatility regime
+    risk_limits.scale_by_volatility(vix / 100 if vix else 0.2)
 
     # Initialize advisor
     advisor = WheelAdvisor(wheel_params, risk_limits)
@@ -101,7 +116,9 @@ def generate_recommendation(
 
     # Get real market data - fail if not available
     try:
-        market_snapshot, confidence = get_market_data_sync(portfolio_value, TICKER)
+        market_snapshot, confidence = get_market_data_sync(
+            portfolio_value, TICKER, risk_free_rate=rf_rate
+        )
         logger.info("Successfully fetched real Unity market data", extra={"confidence": confidence})
         current_price = market_snapshot.current_price
 

--- a/tests/test_databento_integration_failures.py
+++ b/tests/test_databento_integration_failures.py
@@ -24,7 +24,7 @@ async def test_create_snapshot_spot_failure():
         patch("src.unity_wheel.cli.databento_integration.DatabentoIntegration"),
     ):
         with pytest.raises(ValueError, match="Failed to get Unity spot price"):
-            await create_databento_market_snapshot(100_000.0, "U")
+            await create_databento_market_snapshot(100_000.0, "U", risk_free_rate=0.05)
     mock_client.close.assert_awaited_once()
 
 
@@ -50,7 +50,7 @@ async def test_create_snapshot_no_candidates():
         ),
     ):
         with pytest.raises(ValueError, match="No Unity options found"):
-            await create_databento_market_snapshot(100_000.0, "U")
+            await create_databento_market_snapshot(100_000.0, "U", risk_free_rate=0.05)
     mock_client.close.assert_awaited_once()
 
 
@@ -61,4 +61,4 @@ def test_sync_wrapper_propagates_errors():
         side_effect=ValueError("bad"),
     ):
         with pytest.raises(ValueError, match="bad"):
-            get_market_data_sync(1.0)
+            get_market_data_sync(1.0, risk_free_rate=0.05)


### PR DESCRIPTION
## Summary
- pull risk-free rate and volatility regime from FRED
- scale risk limits based on VIX level
- pass risk-free rate to market snapshot builder
- document FRED usage in README
- adjust tests for new databento helpers

## Testing
- `python3 -m pytest tests -v --tb=short` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848c50bc4a8833081a11cae5b3681fe