### PR TITLE
Enhance risk checks and reporting

### DIFF
--- a/src/unity_wheel/api/types.py
+++ b/src/unity_wheel/api/types.py
@@ -10,7 +10,7 @@ Action = Literal["HOLD", "ADJUST", "ROLL", "CLOSE"]
 OptionType = Literal["call", "put"]
 
 
-class RiskMetrics(TypedDict):
+class RiskMetrics(TypedDict, total=False):
     """Risk metrics for recommendation."""
 
     max_loss: float
@@ -18,7 +18,9 @@ class RiskMetrics(TypedDict):
     expected_return: float
     edge_ratio: float
     var_95: float
+    cvar_95: float
     margin_required: float
+    margin_utilization: float
 
 
 class Recommendation(TypedDict):
@@ -29,6 +31,7 @@ class Recommendation(TypedDict):
     confidence: float
     risk: RiskMetrics
     details: Dict[str, Any]
+    risk_report: Dict[str, Any]
 
 
 class PositionData(TypedDict):

--- a/tests/test_risk_limit_breach.py
+++ b/tests/test_risk_limit_breach.py
@@ -1,0 +1,33 @@
+import sys
+from unittest.mock import Mock
+
+sys.modules["google"] = Mock()
+sys.modules["google.cloud"] = Mock()
+sys.modules["google.cloud.exceptions"] = Mock()
+
+from src.unity_wheel.risk.analytics import RiskAnalyzer, RiskMetrics, RiskLimits
+
+
+def test_risk_limit_breach_report():
+    limits = RiskLimits(max_var_95=0.01, max_cvar_95=0.02, max_margin_utilization=0.1)
+    analyzer = RiskAnalyzer(limits=limits)
+
+    metrics = RiskMetrics(
+        var_95=3000,
+        var_99=4000,
+        cvar_95=3500,
+        cvar_99=4500,
+        kelly_fraction=0.2,
+        portfolio_delta=150,
+        portfolio_gamma=20,
+        portfolio_vega=6000,
+        portfolio_theta=-500,
+        margin_requirement=50000,
+        margin_utilization=0.6,
+    )
+
+    breaches = analyzer.check_limits(metrics, 100000)
+    report = analyzer.generate_risk_report(metrics, breaches, 100000)
+
+    assert breaches
+    assert report["breaches"]


### PR DESCRIPTION
## Summary
- extend API types with CVaR and margin utilization
- calculate VaR/CVaR from historical returns in advisor
- check risk limits and generate risk reports
- attach risk report to recommendations
- add unit test for risk limit breaches

## Testing
- `pytest tests/test_risk_limit_breach.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6848c5283188833080dd3c568140976b