### PR TITLE
Add risk limit checks with report

### DIFF
--- a/src/unity_wheel/api/advisor.py
+++ b/src/unity_wheel/api/advisor.py
@@ -11,7 +11,14 @@ from ..analytics import UnityAssignmentModel
 from ..math import probability_itm_validated
 from ..metrics import metrics_collector
 from ..models import Account, Position
-from ..risk import BorrowingCostAnalyzer, RiskAnalyzer, RiskLimits, analyze_borrowing_decision
+from ..risk import (
+    BorrowingCostAnalyzer,
+    RiskAnalyzer,
+    RiskLimits,
+    RiskLevel,
+    RiskMetrics as AnalyticsMetrics,
+    analyze_borrowing_decision,
+)
 from ..risk.advanced_financial_modeling import AdvancedFinancialModeling
 from ..strategy import WheelParameters, WheelStrategy
 from ..utils import (
@@ -290,6 +297,7 @@ class WheelAdvisor:
 
             # Calculate comprehensive risk metrics
             risk_metrics = self._calculate_risk_metrics(
+                ticker=market_snapshot["ticker"],
                 strike=strike_rec.strike,
                 premium=strike_rec.premium,
                 contracts=contracts,
@@ -309,6 +317,35 @@ class WheelAdvisor:
             )
 
             risk_metrics["edge_ratio"] = edge
+
+            dataclass_metrics = AnalyticsMetrics(
+                var_95=risk_metrics["var_95"],
+                var_99=risk_metrics["var_95"],
+                cvar_95=risk_metrics["cvar_95"],
+                cvar_99=risk_metrics["cvar_95"],
+                kelly_fraction=0.0,
+                portfolio_delta=0.0,
+                portfolio_gamma=0.0,
+                portfolio_vega=0.0,
+                portfolio_theta=0.0,
+                margin_requirement=risk_metrics["margin_required"],
+                margin_utilization=risk_metrics["margin_required"] / account.cash_balance,
+            )
+
+            breaches = self.risk_analyzer.check_limits(
+                dataclass_metrics, account.cash_balance
+            )
+            risk_report = self.risk_analyzer.generate_risk_report(
+                dataclass_metrics, breaches, account.cash_balance
+            )
+
+            for b in breaches:
+                if b.severity == RiskLevel.CRITICAL:
+                    confidence *= 0.5
+                elif b.severity == RiskLevel.HIGH:
+                    confidence *= 0.7
+                else:
+                    confidence *= 0.9
 
             # Overall confidence
             confidence = min(
@@ -344,6 +381,7 @@ class WheelAdvisor:
                         "edge": edge,
                         "decision_time": elapsed,
                     },
+                    risk_report=risk_report,
                 )
 
             # Add borrowing metrics to risk metrics
@@ -394,6 +432,7 @@ class WheelAdvisor:
                         0, strike_rec.strike * 100 * contracts - available_cash
                     ),
                 },
+                risk_report=risk_report,
             )
 
             # Log successful decision
@@ -547,6 +586,7 @@ class WheelAdvisor:
 
     def _calculate_risk_metrics(
         self,
+        ticker: str,
         strike: float,
         premium: float,
         contracts: int,
@@ -556,6 +596,9 @@ class WheelAdvisor:
         portfolio_value: float,
     ) -> RiskMetrics:
         """Calculate comprehensive risk metrics."""
+        import numpy as np
+        from scipy import stats
+
         # Max loss (assignment at strike)
         max_loss = strike * self.constraints.CONTRACTS_PER_TRADE * contracts
 
@@ -564,8 +607,21 @@ class WheelAdvisor:
         premium_return = (premium / strike) * (365 / days_to_expiry)
         expected_return = premium_return * (1 - probability_itm)
 
-        # VaR calculation (simplified)
-        position_var = max_loss * volatility * 1.65 * probability_itm
+        position_value = strike * self.constraints.CONTRACTS_PER_TRADE * contracts
+
+        # Historical returns for VaR/CVaR
+        returns = self._load_historical_returns(ticker)
+        if returns is None:
+            # Fallback using volatility
+            daily_vol = volatility / np.sqrt(252)
+            quantiles = np.linspace(0.001, 0.999, 252)
+            returns = stats.norm.ppf(quantiles) * daily_vol
+
+        var_pct, _ = self.risk_analyzer.calculate_var(returns, 0.95)
+        cvar_pct, _ = self.risk_analyzer.calculate_cvar(returns, 0.95)
+
+        position_var = position_value * var_pct
+        position_cvar = position_value * cvar_pct
 
         # Margin requirement
         margin_required = strike * self.constraints.CONTRACTS_PER_TRADE * contracts * 0.20
@@ -576,6 +632,7 @@ class WheelAdvisor:
             expected_return=expected_return,
             edge_ratio=0.0,  # Calculated separately
             var_95=position_var,
+            cvar_95=position_cvar,
             margin_required=margin_required,
         )
 
@@ -625,7 +682,39 @@ class WheelAdvisor:
                 expected_return=0.0,
                 edge_ratio=0.0,
                 var_95=0.0,
+                cvar_95=0.0,
                 margin_required=0.0,
             ),
             details={},
+            risk_report={},
         )
+
+    def _load_historical_returns(self, ticker: str, days: int = 252):
+        """Load recent returns from local storage if available."""
+        import os
+        from pathlib import Path
+        import numpy as np
+        try:
+            import duckdb
+        except Exception:  # pragma: no cover - duckdb optional in some envs
+            return None
+
+        db_path = Path(os.path.expanduser("~/.wheel_trading/cache/wheel_cache.duckdb"))
+        if not db_path.exists():
+            return None
+
+        try:
+            conn = duckdb.connect(str(db_path))
+            rows = conn.execute(
+                "SELECT returns FROM price_history WHERE symbol = ? ORDER BY date DESC LIMIT ?",
+                [ticker, days],
+            ).fetchall()
+            conn.close()
+        except Exception as e:  # pragma: no cover - ignore DB issues
+            logger.warning("load_returns_failed", error=str(e))
+            return None
+
+        returns = [float(r[0]) for r in rows if r[0] is not None]
+        if len(returns) < 20:
+            return None
+        return np.array(list(reversed(returns)))

--- a/src/unity_wheel/api/types.py
+++ b/src/unity_wheel/api/types.py
@@ -18,6 +18,7 @@ class RiskMetrics(TypedDict):
     expected_return: float
     edge_ratio: float
     var_95: float
+    cvar_95: float
     margin_required: float
 
 
@@ -29,6 +30,7 @@ class Recommendation(TypedDict):
     confidence: float
     risk: RiskMetrics
     details: Dict[str, Any]
+    risk_report: Dict[str, Any]
 
 
 class PositionData(TypedDict):

--- a/tests/test_risk_breach.py
+++ b/tests/test_risk_breach.py
@@ -1,0 +1,37 @@
+import sys
+import types
+
+sys.modules.setdefault("google", types.ModuleType("google"))
+sys.modules.setdefault("google.cloud", types.ModuleType("google.cloud"))
+sys.modules.setdefault("google.cloud.storage", types.ModuleType("google.cloud.storage"))
+exc_mod = types.ModuleType("google.cloud.exceptions")
+setattr(exc_mod, "NotFound", type("NotFound", (), {}))
+sys.modules.setdefault("google.cloud.exceptions", exc_mod)
+
+from src.unity_wheel.risk.analytics import RiskAnalyzer, RiskLimits, RiskMetrics
+
+
+def test_risk_limit_breach_detection():
+    limits = RiskLimits(max_var_95=0.05, max_cvar_95=0.07)
+    analyzer = RiskAnalyzer(limits=limits)
+
+    metrics = RiskMetrics(
+        var_95=100.0,
+        var_99=120.0,
+        cvar_95=150.0,
+        cvar_99=170.0,
+        kelly_fraction=0.2,
+        portfolio_delta=0.0,
+        portfolio_gamma=0.0,
+        portfolio_vega=0.0,
+        portfolio_theta=0.0,
+        margin_requirement=0.0,
+        margin_utilization=0.0,
+    )
+
+    breaches = analyzer.check_limits(metrics, portfolio_value=1000.0)
+    report = analyzer.generate_risk_report(metrics, breaches, 1000.0)
+
+    assert breaches
+    assert any(b.metric == "var_95" for b in breaches)
+    assert report["breaches"]


### PR DESCRIPTION
## Summary
- calculate VaR/CVaR from historical data when sizing risk
- enforce risk limits via `RiskAnalyzer.check_limits`
- include generated risk reports in `Recommendation`
- expose CVaR in API types
- test that risk limit breaches are reported

## Testing
- `python -m pytest tests/test_risk_breach.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6848c5ba67088330b24cc7710c94fff6