### PR TITLE
Enhance switch analysis with breakeven metric

### DIFF
--- a/tests/test_position_evaluator.py
+++ b/tests/test_position_evaluator.py
@@ -1,7 +1,5 @@
 """Test position evaluation and comparison framework."""
 
-from datetime import datetime, timedelta
-
 import pytest
 
 from src.unity_wheel.models.position import Position
@@ -79,6 +77,8 @@ class TestPositionEvaluator:
 
         # This should be beneficial (collecting more premium)
         assert analysis.new_expected_value > analysis.current_expected_value
+        assert analysis.breakeven_days != float("inf")
+        assert analysis.breakeven_days > 0
 
     def test_analyze_switch_not_beneficial(self):
         """Test analyzing a non-beneficial switch."""


### PR DESCRIPTION
## Summary
- extend `SwitchAnalysis` dataclass with `breakeven_days`
- compute days needed to recoup switching costs in `PositionEvaluator`
- validate `breakeven_days` in unit tests

## Testing
- `pytest tests/test_position_evaluator.py -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6848c4dfdbf48330998cdf2c4e49e25a