### PR TITLE
Remove deprecated GCS options from examples and tests

### DIFF
--- a/tests/test_complete_integration.py
+++ b/tests/test_complete_integration.py
@@ -27,7 +27,7 @@ async def test_complete_integration():
 
     # 1. Initialize storage layer
     print("\n1️⃣ Initializing Storage Layer...")
-    storage = Storage(StorageConfig(enable_gcs_backup=False))  # Local only for test
+    storage = Storage()  # Local only for test
     await storage.initialize()
     print("   ✅ DuckDB initialized")
 

--- a/tests/test_fred_integration.py
+++ b/tests/test_fred_integration.py
@@ -70,7 +70,6 @@ async def test_integration():
     print("\n6. Testing Storage Stats:")
     stats = await storage.get_storage_stats()
     print(f"   Cache location: {storage.config.cache_config.cache_dir}")
-    print(f"   GCS enabled: {stats['gcs_enabled']}")
     if "tables" in stats:
         for table, info in stats["tables"].items():
             if table.startswith("fred"):

--- a/tools/analysis/pull_databento_integrated.py
+++ b/tools/analysis/pull_databento_integrated.py
@@ -16,7 +16,7 @@ from src.unity_wheel.databento import DatabentoClient
 from src.unity_wheel.databento.databento_storage_adapter import DatabentoStorageAdapter
 from src.unity_wheel.databento.integration import DatentoIntegration
 from src.unity_wheel.databento.validation import DataValidator
-from src.unity_wheel.storage import Storage, StorageConfig
+from src.unity_wheel.storage import Storage
 from src.unity_wheel.utils import setup_structured_logging
 
 
@@ -30,7 +30,7 @@ async def pull_wheel_data_integrated():
     print("📋 Following DATABENTO_STORAGE_PLAN.md")
 
     # Initialize unified storage (DuckDB + optional GCS)
-    storage = Storage(StorageConfig(enable_gcs_backup=bool(os.getenv("GCP_PROJECT_ID"))))
+    storage = Storage()
     await storage.initialize()
 
     # Initialize Databento storage adapter

--- a/tools/collect_all_unity_data.py
+++ b/tools/collect_all_unity_data.py
@@ -27,7 +27,7 @@ from src.unity_wheel.data_providers.databento.databento_storage_adapter import (
     DatabentoStorageAdapter,
 )
 from src.unity_wheel.storage.duckdb_cache import CacheConfig, DuckDBCache
-from src.unity_wheel.storage.storage import Storage
+from src.unity_wheel.storage.storage import Storage, StorageConfig
 from src.unity_wheel.utils.logging import StructuredLogger
 
 logger = StructuredLogger(logging.getLogger(__name__))
@@ -563,11 +563,8 @@ async def main():
         # Create storage stack
         from pathlib import Path
 
-        from src.unity_wheel.storage.storage import StorageConfig
-
         cache_config = CacheConfig(cache_dir=Path(db_path).parent)
-        storage_config = StorageConfig(cache_config=cache_config, enable_gcs_backup=False)
-        storage = Storage(storage_config)
+        storage = Storage(StorageConfig(cache_config=cache_config))
         await storage.initialize()
 
         adapter = DatabentoStorageAdapter(storage)


### PR DESCRIPTION
## Summary
- drop `enable_gcs_backup` and `gcs_enabled` usage from integration tests
- instantiate `Storage()` without GCS params in data tools

## Testing
- `pytest tests/test_math_simple.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6848cec4b4fc83308dbe4b45a6286751