### PR TITLE
Remove GCS docs

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -83,7 +83,7 @@ databento:
   symbols: ["U"]  # Unity only by default
   storage:
     local_days: 30      # Recent data cached locally
-    cloud_enabled: false # Set true for GCS/BigQuery
+    cloud_enabled: false # Reserved for future use
   filters:
     min_volume: 10      # Skip illiquid options
     max_spread_pct: 0.5 # Skip wide spreads

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ python run.py --performance
 - **< $50/month** total operational cost
 - No streaming subscriptions
 - Intelligent caching reduces API calls by 90%+
-- Optional cloud backup (GCS) for long-term analysis
+- Uses Google Cloud Secret Manager for credentials (only GCP dependency)
 
 ## 🏗️ Architecture
 
@@ -56,10 +56,6 @@ Store in cache → Generate recommendation
    - 30-day automatic cleanup
    - < 5GB typical usage
 
-2. **Optional GCS Backup**
-   - Raw API responses
-   - Parquet exports for analysis
-   - Lifecycle policies for cost control
 
 ## 📁 Project Structure
 
@@ -102,6 +98,8 @@ pip install -r requirements-dev.txt
 
 # Set up credentials
 python scripts/setup-secrets.py
+# This stores your API keys in Google Cloud Secret Manager or
+# local encrypted storage depending on the environment.
 
 # Verify installation
 python -m unity_wheel.validate
@@ -301,6 +299,8 @@ poetry run pre-commit run --all-files
 - OAuth tokens auto-refresh
 - No credentials in code or config
 - Machine-specific encryption keys
+- Google Cloud Secret Manager stores credentials securely
+  (the project's only Google Cloud dependency)
 
 ## 📝 Documentation
 

--- a/docs/archive/FRED_INTEGRATION.md
+++ b/docs/archive/FRED_INTEGRATION.md
@@ -23,7 +23,7 @@ api_key = get_ofred_api_key()
 
 ### 2. **Unified Storage**
 
-FRED data is stored in the DuckDB cache with optional GCS backup:
+FRED data is stored in the DuckDB cache:
 
 ```python
 from src.unity_wheel.storage.storage import Storage
@@ -63,7 +63,6 @@ FRED data is stored in these DuckDB tables:
 ### Storage Locations
 
 - **Local Cache**: `~/.wheel_trading/cache/wheel_cache.duckdb`
-- **GCS Backup**: `gs://wheel-processed/fred_*` (if enabled)
 
 ### Data Series
 
@@ -185,5 +184,5 @@ If you have existing FRED data in SQLite:
 ## Cost
 
 - **FRED API**: Free (120 requests/minute limit)
-- **Storage**: <50MB local, optional GCS backup
-- **Estimated monthly cost**: $0 (local only) or <$0.01 (with GCS)
+- **Storage**: <50MB local
+- **Estimated monthly cost**: $0

--- a/docs/archive/PULL_WHEN_ASKED_MIGRATION.md
+++ b/docs/archive/PULL_WHEN_ASKED_MIGRATION.md
@@ -16,7 +16,7 @@ The Unity Wheel Trading Bot has been successfully migrated from a continuous mon
 ### After (v2.0)
 - On-demand data fetching only
 - REST APIs only (no WebSocket)
-- Single storage layer (DuckDB + optional GCS)
+- Single storage layer (DuckDB only)
 - Zero background processes
 - Simple, cost-effective infrastructure
 
@@ -29,11 +29,6 @@ The Unity Wheel Trading Bot has been successfully migrated from a continuous mon
    - 30-day TTL with automatic cleanup
    - SQL interface for complex queries
    - < 5GB typical disk usage
-
-2. **GCS Adapter** (`src/unity_wheel/storage/gcs_adapter.py`)
-   - Optional cold backup only
-   - Lifecycle policies (Standard → Nearline → Delete)
-   - No hot queries or BigQuery
 
 3. **Unified Storage** (`src/unity_wheel/storage/storage.py`)
    - Single `get_or_fetch` pattern for all data
@@ -92,7 +87,6 @@ The Unity Wheel Trading Bot has been successfully migrated from a continuous mon
 ### Environment Variables
 - Same pattern: `WHEEL_SECTION__PARAM`
 - Credentials use SecretManager
-- Optional GCS configuration
 
 ## Cost Impact
 
@@ -101,7 +95,7 @@ The Unity Wheel Trading Bot has been successfully migrated from a continuous mon
 | Component | Before (v1.0) | After (v2.0) |
 |-----------|---------------|--------------|
 | Compute | $50-100 (always on) | < $5 (on demand) |
-| Storage | $20-50 (multiple DBs) | < $10 (DuckDB + GCS) |
+| Storage | $20-50 (multiple DBs) | < $10 (DuckDB only) |
 | APIs | $100+ (streaming) | < $40 (cached REST) |
 | **Total** | **$170-250** | **< $55** |
 

--- a/docs/archive/SCHWAB_DATA_COLLECTION.md
+++ b/docs/archive/SCHWAB_DATA_COLLECTION.md
@@ -24,7 +24,6 @@ If data is stale (> TTL):
     → SchwabDataFetcher
     → Schwab API (with rate limiting)
     → Store in DuckDB cache
-    → Optional GCS backup
     ↓
 Return data to user
 ```
@@ -172,7 +171,6 @@ Assumptions:
 API Calls: 50 (after cache)
 Schwab API: Free (no cost)
 Storage: < 100MB DuckDB
-GCS Backup: < $1/month
 Total: < $1/month
 ```
 

--- a/docs/archive/setup-summary.md
+++ b/docs/archive/setup-summary.md
@@ -21,14 +21,13 @@
 - Security: KMS, Secret Manager, Binary Authorization, Security Center
 - Monitoring: Logging, Monitoring, Cloud Trace
 - Compute: Cloud Run, Cloud Functions, App Engine
-- Storage: Artifact Registry, Cloud Storage
+- Storage: Artifact Registry
 - Database: Firestore, Cloud SQL, Redis
 - Messaging: Pub/Sub, Cloud Scheduler
 
 ### Resources Created:
 
 - Artifact Registry: us-central1-docker.pkg.dev/wheel-strategy-202506/wheel-trading
-- Logs Bucket: gs://wheel-strategy-202506-logs
 - Monitoring Channel: Email alerts to njrun1804@gmail.com
 
 ## 🚀 Next Steps
@@ -64,7 +63,6 @@ gh api repos/njrun1804/wheel-trading/vulnerability-alerts
 
 ## 🔐 Security Features
 
-- Audit logs exported to Cloud Storage
 - Vulnerability scanning on all code pushes
 - Automated dependency updates
 - Secret scanning with push protection


### PR DESCRIPTION
## Summary
- remove optional GCS backup docs and notes
- clarify only Google Cloud dependency is Secret Manager
- strip Cloud Storage references from archived documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6848cec326288330ac634dd8b2f9fd4b