### PR TITLE
Mac M4 optimization update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,34 @@ python run.py --performance
 ./scripts/monitor.sh
 ```
 
+## 🍎 M4 MacBook Pro Setup
+
+The project includes optimizations specifically for macOS 15.5 on the 12‑core M4 Pro MacBook. To enable them:
+
+1. **Run the tuning script once** (requires sudo):
+   ```bash
+   ./scripts/mac-optimize.sh
+   ```
+2. **Use the optimized data loader** when fetching history:
+   ```bash
+   python tools/data/fetch_unity_data_optimized.py
+   ```
+3. **Increase parallelism** to match your hardware by setting:
+   ```bash
+   export WHEEL_DATABENTO__LOADER__MAX_WORKERS=12
+   ```
+   (the default in `config.yaml` is already 12)
+4. **Confirm compiled libraries** and disable pure Python mode for best performance:
+   ```bash
+   export USE_PURE_PYTHON=false
+   ```
+5. **Validate the environment** before running any commands:
+   ```bash
+   source .codex/.container_env
+   python .codex/check_environment.py
+   ```
+
+
 ## 💰 Cost Efficiency
 
 - **< $50/month** total operational cost

--- a/config.yaml
+++ b/config.yaml
@@ -205,7 +205,7 @@ databento:
 
   # Data loader configuration
   loader:
-    max_workers: 8                  # Parallel processing workers
+    max_workers: 12                 # Parallel processing workers (M4 Pro)
     chunk_size: 250                 # Symbols per chunk
     max_requests_per_second: 100    # Rate limit
     retry_delays: [1, 2, 5, 10]     # Retry delays in seconds


### PR DESCRIPTION
## Summary
- document MacBook Pro M4 setup steps
- increase default workers to 12

## Testing
- `test_container.sh`
- `pytest -q` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848ce69c8188330a908c20a6bf5447d