### PR TITLE
Add container_commit helper script

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -225,7 +225,7 @@ python -c "from src.unity_wheel.math.options import black_scholes_price_validate
 ./.codex/container_test.sh
 
 # Quick commit
-./.codex/container_commit.sh "commit message"
+./.codex/container_commit.sh "commit message"  # stages and commits all changes
 ```
 
 ## Environment Variables

--- a/.codex/CONTAINER_README.md
+++ b/.codex/CONTAINER_README.md
@@ -68,7 +68,7 @@ Tests that everything is working:
 ```
 
 ### 💾 container_commit.sh
-Quick git commit for container changes:
+Stage and commit all changes in one step:
 ```bash
 ./.codex/container_commit.sh "your commit message"
 ```

--- a/.codex/container_commit.sh
+++ b/.codex/container_commit.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Simple helper to stage all changes and create a git commit.
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 \"commit message\"" >&2
+  exit 1
+fi
+
+msg="$1"
+
+# Stage all changes
+git add -A
+
+# Only commit if there is something to commit
+if git diff --cached --quiet; then
+  echo "Nothing to commit" >&2
+  exit 0
+fi
+
+git commit -m "$msg"

--- a/README.md
+++ b/README.md
@@ -280,6 +280,19 @@ poetry run mypy src/ --strict
 poetry run pre-commit run --all-files
 ```
 
+### Container Quick Commands
+
+```bash
+# Setup container environment
+./.codex/container_setup.sh
+
+# Run container tests
+./.codex/container_test.sh
+
+# Commit changes quickly
+./.codex/container_commit.sh "your commit message"
+```
+
 ## 📈 Performance
 
 ### Calculation Benchmarks


### PR DESCRIPTION
## Summary
- add container_commit helper to streamline git workflow
- document usage in AGENTS and container README
- mention container helper commands in README

## Testing
- `pytest tests/test_config.py -v` *(fails: ModuleNotFoundError: No module named 'google')*
- `pytest tests/test_math_simple.py -v` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6848d06215388330a4e1297f6085a34f