### PR TITLE
Fix import paths and version check

### DIFF
--- a/.codex/check_environment.py
+++ b/.codex/check_environment.py
@@ -27,7 +27,7 @@ def check_python_version() -> Tuple[bool, str]:
     version = sys.version_info
     version_str = f"{version.major}.{version.minor}.{version.micro}"
 
-    if version.major == 3 and version.minor >= 8:
+    if version.major == 3 and version.minor >= 9:
         return True, version_str
     else:
         return False, version_str
@@ -56,12 +56,12 @@ def check_package(package_name: str, import_path: str = None) -> Tuple[bool, str
 def check_unity_wheel_modules() -> Dict[str, Tuple[bool, str]]:
     """Check Unity Wheel specific modules."""
     modules_to_check = {
-        "unity_trading": "unity_trading",
-        "unity_trading.math": "unity_trading.math.options",
-        "unity_trading.strategy": "unity_trading.strategy.wheel",
-        "unity_trading.api": "unity_trading.api.advisor",
-        "unity_trading.utils": "unity_trading.utils.position_sizing",
-        "unity_trading.risk": "unity_trading.risk.analytics",
+        "src.unity_wheel": "src.unity_wheel",
+        "src.unity_wheel.math": "src.unity_wheel.math.options",
+        "src.unity_wheel.strategy": "src.unity_wheel.strategy.wheel",
+        "src.unity_wheel.api": "src.unity_wheel.api.advisor",
+        "src.unity_wheel.utils": "src.unity_wheel.utils.position_sizing",
+        "src.unity_wheel.risk": "src.unity_wheel.risk.analytics",
     }
 
     results = {}
@@ -93,7 +93,7 @@ def test_core_functionality() -> List[Tuple[str, bool, str]]:
 
     # Test 1: Basic math operations
     try:
-        from unity_trading.math.options import black_scholes_price_validated
+        from src.unity_wheel.math.options import black_scholes_price_validated
 
         result = black_scholes_price_validated(100, 100, 1, 0.05, 0.2, "call")
         if result.confidence > 0.9:
@@ -113,7 +113,7 @@ def test_core_functionality() -> List[Tuple[str, bool, str]]:
 
     # Test 2: Strategy module
     try:
-        from unity_trading.strategy.wheel import WheelStrategy
+        from src.unity_wheel.strategy.wheel import WheelStrategy
 
         strategy = WheelStrategy()
         tests.append(("Wheel strategy creation", True, "Strategy object created"))
@@ -122,7 +122,7 @@ def test_core_functionality() -> List[Tuple[str, bool, str]]:
 
     # Test 3: Position sizing
     try:
-        from unity_trading.utils.position_sizing import calculate_position_size
+        from src.unity_wheel.utils.position_sizing import calculate_position_size
 
         tests.append(("Position sizing import", True, "Module imported successfully"))
     except Exception as e:
@@ -149,7 +149,7 @@ def main():
     if python_ok:
         print(f"✅ Python version: {colored(python_version, GREEN)}")
     else:
-        print(f"❌ Python version: {colored(python_version, RED)} (requires 3.8+)")
+        print(f"❌ Python version: {colored(python_version, RED)} (requires 3.9+)")
 
     print(f"📁 Python executable: {sys.executable}")
     print(f"📁 Current working directory: {os.getcwd()}")

--- a/.codex/diagnose.sh
+++ b/.codex/diagnose.sh
@@ -79,10 +79,10 @@ except ImportError:
 # Try project import
 sys.path.insert(0, '.')
 try:
-    from unity_trading.math import options
-    print('   ✅ Unity trading imports work')
+    from src.unity_wheel.math import options
+    print('   ✅ Unity Wheel imports work')
 except ImportError as e:
-    print(f'   ⚠️  Unity trading import failed: {str(e).split(\":\")[0]}')
+    print(f'   ⚠️  Unity Wheel import failed: {str(e).split(\":\")[0]}')
 "
 echo ""
 

--- a/.codex/instant_setup.sh
+++ b/.codex/instant_setup.sh
@@ -21,7 +21,7 @@ python3 -m pip install numpy pandas scipy pydantic 2>/dev/null && echo "✓ Pack
 cd - >/dev/null
 
 # 3. Set PYTHONPATH after packages
-export PYTHONPATH="$(pwd):$(pwd)/unity_trading:$PYTHONPATH"
+export PYTHONPATH="$(pwd):$PYTHONPATH"
 
 # 4. Create directories
 mkdir -p /tmp/.wheel/cache /tmp/.wheel/secrets 2>/dev/null

--- a/.codex/quick_setup.sh
+++ b/.codex/quick_setup.sh
@@ -39,7 +39,7 @@ cat > .codex/.env <<EOF
 export USE_MOCK_DATA=true
 export OFFLINE_MODE=true
 export DATABENTO_SKIP_VALIDATION=true
-export PYTHONPATH="$(pwd):$(pwd)/unity_trading:\$PYTHONPATH"
+export PYTHONPATH="$(pwd):\$PYTHONPATH"
 export LOG_LEVEL=INFO
 EOF
 

--- a/.codex/setup_offline.sh
+++ b/.codex/setup_offline.sh
@@ -38,7 +38,7 @@ echo "✅ Environment file created: .codex/.env"
 # Test Python availability
 echo "🐍 Testing Python environment..."
 if ! command -v python &> /dev/null; then
-    echo "❌ Python not found! Please ensure Python 3.8+ is available."
+    echo "❌ Python not found! Please ensure Python 3.9+ is available."
     exit 1
 fi
 
@@ -99,7 +99,7 @@ export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 
 python -c "
 try:
-    from unity_trading.math.options import black_scholes_price_validated
+    from src.unity_wheel.math.options import black_scholes_price_validated
     print('✅ Math module imported successfully')
 except ImportError as e:
     print(f'❌ Math module import failed: {e}')
@@ -108,7 +108,7 @@ except ImportError as e:
 
 python -c "
 try:
-    from unity_trading.strategy.wheel import WheelStrategy
+    from src.unity_wheel.strategy.wheel import WheelStrategy
     print('✅ Strategy module imported successfully')
 except ImportError as e:
     print(f'❌ Strategy module import failed: {e}')
@@ -117,7 +117,7 @@ except ImportError as e:
 
 python -c "
 try:
-    from unity_trading.utils.position_sizing import calculate_position_size
+    from src.unity_wheel.utils.position_sizing import calculate_position_size
     print('✅ Position sizing module imported successfully')
 except ImportError as e:
     print(f'❌ Position sizing module import failed: {e}')
@@ -127,7 +127,7 @@ except ImportError as e:
 # Test core functionality
 echo "🧪 Testing core functionality..."
 python -c "
-from unity_trading.math.options import black_scholes_price_validated as bs
+from src.unity_wheel.math.options import black_scholes_price_validated as bs
 result = bs(100, 100, 1, 0.05, 0.2, 'call')
 if result.confidence > 0.9:
     print(f'✅ Options pricing works: ${result.value:.2f} (confidence: {result.confidence:.1%})')
@@ -154,7 +154,7 @@ echo "📁 Added $(pwd) to PYTHONPATH"
 
 # Verify setup
 python -c "
-from unity_trading import __version__
+from src.unity_wheel import __version__
 print(f'✅ Unity Wheel Trading Bot v{__version__} ready!')
 " 2>/dev/null || echo "⚠️  Unity Wheel import issues - check setup"
 
@@ -176,7 +176,7 @@ echo "🔧 To activate in new sessions:"
 echo "   source .codex/activate.sh"
 echo ""
 echo "🚀 Quick test commands:"
-echo "   python -c \"from unity_trading.math import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))\""
-echo "   python -c \"from unity_trading.strategy.wheel import WheelStrategy; print('Strategy ready')\""
+echo "   python -c \"from src.unity_wheel.math import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))\""
+echo "   python -c \"from src.unity_wheel.strategy.wheel import WheelStrategy; print('Strategy ready')\""
 echo ""
 echo "📖 For full documentation: .codex/ENVIRONMENT_SETUP.md"

--- a/src/unity_wheel/utils/validate.py
+++ b/src/unity_wheel/utils/validate.py
@@ -64,7 +64,7 @@ class EnvironmentValidator:
     def _check_python_version(self) -> None:
         """Check Python version meets requirements."""
         required_major = 3
-        required_minor = 12
+        required_minor = 9
 
         current_major = sys.version_info.major
         current_minor = sys.version_info.minor


### PR DESCRIPTION
## Summary
- update python version requirement to 3.9+
- update scripts to import `src.unity_wheel` modules
- drop references to old `unity_trading` paths

## Testing
- `pytest tests/test_math_simple.py -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6848d060d2148330853cc823bda06049