### PR TITLE
Standardize shell script safety

### DIFF
--- a/.codex/container_setup_v26.sh
+++ b/.codex/container_setup_v26.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Comprehensive Container Setup for Unity Wheel Trading Bot v2.2
 # Handles numpy, sklearn, and hypothesis dependencies with proper fallbacks
 
-set -e
 
 echo "🚀 UNITY WHEEL CONTAINER SETUP v26"
 echo "=================================="

--- a/.codex/container_setup_v27.sh
+++ b/.codex/container_setup_v27.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Comprehensive Container Setup for Unity Wheel Trading Bot v2.2
 # Handles numpy, sklearn, hypothesis, and essential dependencies with proper fallbacks
 
-set -e
 
 echo "🚀 UNITY WHEEL CONTAINER SETUP v28"
 echo "=================================="

--- a/.codex/container_setup_v28.sh
+++ b/.codex/container_setup_v28.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Comprehensive Container Setup for Unity Wheel Trading Bot v2.2
 # Handles numpy, sklearn, hypothesis, and essential dependencies with proper fallbacks
 
-set -e
 
 echo "🚀 UNITY WHEEL CONTAINER SETUP v29"
 echo "=================================="

--- a/.codex/container_setup_v29.sh
+++ b/.codex/container_setup_v29.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Comprehensive Container Setup for Unity Wheel Trading Bot v2.2
 # Handles numpy, sklearn, hypothesis, and essential dependencies with proper fallbacks
 
-set -e
 
 echo "🚀 UNITY WHEEL CONTAINER SETUP v30"
 echo "=================================="

--- a/.codex/container_setup_v30.sh
+++ b/.codex/container_setup_v30.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Comprehensive Container Setup for Unity Wheel Trading Bot v2.2
 # Handles numpy, sklearn, hypothesis, and essential dependencies with proper fallbacks
 
-set -e
 
 echo "🚀 UNITY WHEEL CONTAINER SETUP v31"
 echo "=================================="

--- a/.codex/container_setup_v31.sh
+++ b/.codex/container_setup_v31.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Comprehensive Container Setup for Unity Wheel Trading Bot v2.2
 # Handles numpy, sklearn, hypothesis, and essential dependencies with proper fallbacks
 
-set -e
 
 echo "🚀 UNITY WHEEL CONTAINER SETUP v32"
 echo "=================================="

--- a/.codex/container_setup_v32.sh
+++ b/.codex/container_setup_v32.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Comprehensive Container Setup for Unity Wheel Trading Bot v2.2
 # Handles numpy, sklearn, hypothesis, and essential dependencies with proper fallbacks
 
-set -e
 
 echo "🚀 UNITY WHEEL CONTAINER SETUP v32"
 echo "=================================="

--- a/.codex/diagnose.sh
+++ b/.codex/diagnose.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Container Diagnostic Script
 # Helps debug container environment issues
 

--- a/.codex/find_optimizations.sh
+++ b/.codex/find_optimizations.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Find optimization opportunities for Codex
 
 echo "🔍 FINDING OPTIMIZATION OPPORTUNITIES"

--- a/.codex/fix_imports.sh
+++ b/.codex/fix_imports.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Fix Import Conflicts - Handles the math module shadowing issue
 # This is a workaround for the unity_trading.math shadowing stdlib math
 

--- a/.codex/instant_setup.sh
+++ b/.codex/instant_setup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Instant setup - Minimal, fast, works immediately
 # This is the most reliable approach for containers
 

--- a/.codex/quick_setup.sh
+++ b/.codex/quick_setup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Quick Container Setup - Minimal approach
 # Handles the math module naming conflict properly
 

--- a/.codex/setup_offline.sh
+++ b/.codex/setup_offline.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Offline setup script for Codex environment
 
-set -e
 
 echo "🚀 CODEX OFFLINE SETUP"
 echo "======================"

--- a/.codex/status.sh
+++ b/.codex/status.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Quick status check for Codex container
 
 echo "🔍 CODEX CONTAINER STATUS"

--- a/.codex/sync_to_src.sh
+++ b/.codex/sync_to_src.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Sync Codex changes back to main src/ directory
 
 echo "🔄 SYNCING CODEX CHANGES TO SRC"

--- a/scripts/autonomous-checks.sh
+++ b/scripts/autonomous-checks.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Autonomous system checks and maintenance
 
-set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"

--- a/scripts/check-data-sources 2.sh
+++ b/scripts/check-data-sources 2.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Quick script to check for improper data sources in Unity Wheel Trading Bot
 # Used by CI/CD and other shell scripts
 
-set -euo pipefail
 
 # Colors (when running interactively)
 if [[ -t 1 ]]; then

--- a/scripts/check-data-sources.sh
+++ b/scripts/check-data-sources.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Quick script to check for improper data sources in Unity Wheel Trading Bot
 # Used by CI/CD and other shell scripts
 
-set -euo pipefail
 
 # Colors (when running interactively)
 if [[ -t 1 ]]; then

--- a/scripts/check-data-validation 2.sh
+++ b/scripts/check-data-validation 2.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Check that data validation with hard exits is properly implemented
 
-set -e
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/check-data-validation.sh
+++ b/scripts/check-data-validation.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Check that data validation with hard exits is properly implemented
 
-set -e
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/commit-workflow.sh
+++ b/scripts/commit-workflow.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Unity Wheel Bot - Complete Commit Workflow
 # Runs all checks, commits, and waits for CI/CD to pass
 
-set -euo pipefail
 
 # Version
 readonly VERSION="1.0.0"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Development helper script for autonomous coding
 
-set -e
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Quick development setup for Unity Wheel Bot
 # Optimized for single-user macOS environment
 
-set -e
 
 echo "🚀 Unity Wheel Bot - Development Setup"
 echo "====================================="

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # On-demand health check script for wheel trading bot
 
-set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"

--- a/scripts/housekeeping.sh
+++ b/scripts/housekeeping.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Unity Wheel Bot v2.2 - Autonomous housekeeping enforcement
 # Exit codes: 0=success, 1=non-critical issues, 2=critical failures
 
-set -euo pipefail
 
 # Version
 readonly VERSION="2.2.0"

--- a/scripts/install-hooks 2.sh
+++ b/scripts/install-hooks 2.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Install git hooks for data validation enforcement
 
-set -e
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Install git hooks for data validation enforcement
 
-set -e
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/mac-optimize.sh
+++ b/scripts/mac-optimize.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Advanced Mac optimizations for Claude Code and development
 
 echo "🚀 Applying advanced Mac optimizations..."

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Periodic maintenance tasks for Unity Wheel Trading Bot
 
-set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # DEPRECATED: This continuous monitoring script has been replaced by on-demand health checks
 #
 # The wheel trading bot now uses a pull-when-asked architecture with no continuous

--- a/scripts/optimize-shell.sh
+++ b/scripts/optimize-shell.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Shell optimizations for Claude Code performance
 
 echo "Applying shell optimizations..."

--- a/scripts/pre-trading-checklist 2.sh
+++ b/scripts/pre-trading-checklist 2.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Pre-trading checklist - Run this EVERY TIME before using the system
 
-set -euo pipefail
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/pre-trading-checklist.sh
+++ b/scripts/pre-trading-checklist.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Pre-trading checklist - Run this EVERY TIME before using the system
 
-set -euo pipefail
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/quick_check.sh
+++ b/scripts/quick_check.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Quick health check for single-user recommendation system
 # Focuses on what matters: math accuracy and recommendation capability
 
-set -e
 
 echo "🔍 Unity Wheel Bot - Quick Check"
 echo "================================"

--- a/scripts/refresh_data.sh
+++ b/scripts/refresh_data.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Automated data refresh script for wheel trading system
 
 # Colors for output

--- a/scripts/validate-live-data-only 2.sh
+++ b/scripts/validate-live-data-only 2.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Script to ensure the system is using ONLY live data, no mock/dummy/fake data
 
-set -euo pipefail
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/validate-live-data-only.sh
+++ b/scripts/validate-live-data-only.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Script to ensure the system is using ONLY live data, no mock/dummy/fake data
 
-set -euo pipefail
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
- standardize shebang headers for all `.sh` scripts
- enforce `set -euo pipefail`
- remove duplicate shebangs at the top of scripts

## Testing
- `pytest tests/test_math_simple.py -v` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6848d0a9b08c8330a1cffbcf8095c15c