### PR TITLE
Fix CI test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           --junit-xml=test-results-${{ matrix.os }}-${{ matrix.test-group }}.xml \
           --maxfail=5 \
           --timeout=300 \
-          -n $PYTEST_XDIST_WORKER_COUNT || true
+          -n $PYTEST_XDIST_WORKER_COUNT
 
     - name: Upload test results
       if: always()
@@ -182,7 +182,7 @@ jobs:
           --cov-report=term:skip-covered \
           --no-cov-on-fail \
           -n auto \
-          -q || true
+          -q
 
     - name: Upload coverage
       uses: codecov/codecov-action@v4
@@ -252,7 +252,7 @@ jobs:
         poetry run pytest tests/test_performance_benchmarks.py \
           --benchmark-only \
           --benchmark-json=benchmark.json \
-          --benchmark-max-time=0.5 || true
+          --benchmark-max-time=0.5
 
     - name: Check performance
       run: |


### PR DESCRIPTION
## Summary
- ensure tests, coverage and benchmark steps fail appropriately

## Testing
- `./.codex/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'google')*
- `python -m pytest tests/test_math_simple.py -v` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6848d24544988330a042adee00e2a3db