### PR TITLE
Add path filter to fast and security workflows

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -15,8 +15,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect code changes to skip workflow on docs-only updates
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          code:
+            - 'src/**'
+            - 'tests/**'
+            - 'pyproject.toml'
+            - 'poetry.lock'
+            - '.github/workflows/**'
+
   # Run all checks in parallel with no dependencies
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest  # Fallback from larger runners
     name: "Lint & Format"
 
@@ -41,6 +63,8 @@ jobs:
       run: pre-commit run --all-files --show-diff-on-failure
 
   type-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest  # Fallback from larger runners
     name: "Type Check"
 
@@ -66,6 +90,8 @@ jobs:
         echo "✅ Type checking completed (non-blocking)"
 
   security:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest  # Fallback from larger runners
     name: "Security Scan"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,8 +14,30 @@ permissions:
   security-events: write
 
 jobs:
+  # Detect code changes to skip workflow on docs-only updates
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          code:
+            - 'src/**'
+            - 'tests/**'
+            - 'pyproject.toml'
+            - 'poetry.lock'
+            - '.github/workflows/**'
+
   # CodeQL - Optimized for Python
   codeql:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10  # Prevent hanging
     steps:
@@ -42,6 +64,8 @@ jobs:
 
   # Dependency scanning
   dependency-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -104,6 +128,8 @@ jobs:
 
   # Secret scanning
   secret-scan:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- trigger fast and security workflows only on code changes using `dorny/paths-filter`
- gate workflow jobs behind the new `changes` job

## Testing
- `python3 -m pytest tests/test_math_simple.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6848d24c39108330b931801e58081e92