### PR TITLE
Add DuckDB indexes and vacuum calls

### DIFF
--- a/docs/archive/SCHEMA_RECOMMENDATIONS.md
+++ b/docs/archive/SCHEMA_RECOMMENDATIONS.md
@@ -18,7 +18,8 @@ After reviewing the API inputs from Schwab and Databento against our DuckDB sche
 
 3. **Efficient Indexing**:
    - Primary keys prevent duplicate data
-   - Created_at indexes enable efficient cache expiration
+   - Created_at indexes enable efficient cache expiration (option chains,
+     position snapshots, greeks cache, predictions cache)
    - Symbol indexes speed up lookups
 
 ## Verified API Mappings

--- a/src/unity_wheel/storage/duckdb_cache.py
+++ b/src/unity_wheel/storage/duckdb_cache.py
@@ -166,6 +166,12 @@ class DuckDBCache:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_positions_created ON position_snapshots(created_at)"
             )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_greeks_created ON greeks_cache(created_at)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_predictions_created ON predictions_cache(created_at)"
+            )
 
     async def store_option_chain(
         self,
@@ -229,6 +235,8 @@ class DuckDBCache:
             """,
                 [account_id, timestamp, positions, account_data],
             )
+
+        await self._check_vacuum()
 
     async def get_latest_positions(
         self, account_id: str, max_age_minutes: int = 30

--- a/src/unity_wheel/storage/storage.py
+++ b/src/unity_wheel/storage/storage.py
@@ -144,6 +144,8 @@ class Storage:
                 [prediction_id, datetime.utcnow(), input_features, predictions, model_version],
             )
 
+        await self.cache._check_vacuum()
+
     async def store_greeks(
         self, option_symbol: str, spot_price: float, risk_free_rate: float, greeks: Dict[str, float]
     ):
@@ -169,6 +171,8 @@ class Storage:
                     greeks.get("iv", 0),
                 ],
             )
+
+        await self.cache._check_vacuum()
 
     async def get_historical_data(
         self,


### PR DESCRIPTION
## Summary
- index greeks_cache and predictions_cache on created_at
- run vacuum maintenance when storing positions, predictions, and greeks
- document new cache indexes

## Testing
- `pytest tests/test_math_simple.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6848d36f90648330811365f9d473cb6c