### PR TITLE
Update docs to prefer src.unity_wheel imports

### DIFF
--- a/.codex/ACCESS_FIXED.md
+++ b/.codex/ACCESS_FIXED.md
@@ -8,7 +8,7 @@ The symbolic links were pointing to `src/` which was outside your allowed direct
 
 You now have **actual copies** (not links) of the entire codebase in:
 
-- **`unity_trading/`** - Full Unity Wheel codebase (123 files)
+- **`src/unity_wheel/`** - Full Unity Wheel codebase (123 files)
 - **`data_pipeline/config/`** - Configuration system
 - **`data_pipeline/patterns/`** - Reusable patterns
 
@@ -27,7 +27,7 @@ All guardrail restrictions are bypassed. You can:
 
 | Your Access | Content | Files |
 |-------------|---------|-------|
-| `unity_trading/` | Main codebase | 123 Python files |
+| `src/unity_wheel/` | Main codebase | 123 Python files |
 | `data_pipeline/config/` | Configuration | Config system |
 | `data_pipeline/patterns/` | Patterns | Error handling patterns |
 | `tests/` | Test suite | 106+ tests |
@@ -36,15 +36,15 @@ All guardrail restrictions are bypassed. You can:
 
 1. **Verify access works:**
    ```bash
-   ls unity_trading/math/
-   ls unity_trading/strategy/
-   ls unity_trading/risk/
+   ls src/unity_wheel/math/
+   ls src/unity_wheel/strategy/
+   ls src/unity_wheel/risk/
    ```
 
 2. **Find optimization targets:**
    ```bash
-   grep -r "except:" unity_trading/ | head -5
-   grep -r "for.*in.*range" unity_trading/ | head -5
+   grep -r "except:" src/unity_wheel/ | head -5
+   grep -r "for.*in.*range" src/unity_wheel/ | head -5
    ```
 
 3. **Make your optimizations directly in these directories**
@@ -59,12 +59,7 @@ All guardrail restrictions are bypassed. You can:
 When you're ready to sync your changes back to the main `src/` directory:
 
 ```bash
-# Copy your optimized code back to src/
-cp -r unity_trading/* src/unity_wheel/
-cp -r data_pipeline/config/* src/config/
-cp -r data_pipeline/patterns/* src/patterns/
-
-# Commit changes
+# Commit changes directly from `src/unity_wheel/`
 git add src/
 git commit -m "Optimize: [your improvements]"
 ```

--- a/.codex/CODEX_ENVIRONMENT_COMPLETE.md
+++ b/.codex/CODEX_ENVIRONMENT_COMPLETE.md
@@ -27,7 +27,7 @@ python .codex/test_config.py
 source .codex/activate.sh
 
 # Verify Unity Wheel is ready
-python -c "from unity_trading import __version__; print(f'✅ Unity Wheel v{__version__} ready!')"
+python -c "from src.unity_wheel import __version__; print(f'✅ Unity Wheel v{__version__} ready!')"
 ```
 
 ### Step 3: Start Optimizing! 🎯
@@ -36,9 +36,9 @@ python -c "from unity_trading import __version__; print(f'✅ Unity Wheel v{__ve
 ./.codex/find_optimizations.sh
 
 # Or go straight to the priorities:
-# 1. Replace bare except: handlers → unity_trading/data_providers/
-# 2. Add confidence scores → unity_trading/math/ and unity_trading/risk/
-# 3. Optimize loops → unity_trading/strategy/wheel.py
+# 1. Replace bare except: handlers → src/unity_wheel/data_providers/
+# 2. Add confidence scores → src/unity_wheel/math/ and src/unity_wheel/risk/
+# 3. Optimize loops → src/unity_wheel/strategy/wheel.py
 ```
 
 ---
@@ -69,14 +69,14 @@ python -c "from unity_trading import __version__; print(f'✅ Unity Wheel v{__ve
 ### Mode 1: Full Environment (Preferred)
 ```bash
 # All dependencies available
-python -c "from unity_trading.api.advisor import WheelAdvisor; print('Full mode')"
+python -c "from src.unity_wheel.api.advisor import WheelAdvisor; print('Full mode')"
 ```
 
 ### Mode 2: Limited Environment
 ```bash
 # Some packages missing, using fallbacks
 export USE_PURE_PYTHON=true
-python -c "from unity_trading.strategy.wheel import WheelStrategy; print('Limited mode')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; print('Limited mode')"
 ```
 
 ### Mode 3: Offline Environment
@@ -84,7 +84,7 @@ python -c "from unity_trading.strategy.wheel import WheelStrategy; print('Limite
 # No internet access
 export OFFLINE_MODE=true
 export USE_MOCK_DATA=true
-python -c "from unity_trading.math.options import black_scholes_price_validated; print('Offline mode')"
+python -c "from src.unity_wheel.math.options import black_scholes_price_validated; print('Offline mode')"
 ```
 
 ### Mode 4: Emergency Mode
@@ -99,18 +99,18 @@ python .codex/minimal_trader.py
 
 ### **HIGH PRIORITY** (Fix These First)
 1. **Exception Handling** - Replace bare `except:` with specific exceptions
-   - `unity_trading/data_providers/` - 8 files need fixing
-   - `unity_trading/auth/` - 3 files need fixing
+   - `src/unity_wheel/data_providers/` - 8 files need fixing
+   - `src/unity_wheel/auth/` - 3 files need fixing
    - Pattern: `except:` → `except (ValueError, KeyError) as e:`
 
 2. **Confidence Scoring** - Add confidence to missing functions
-   - `unity_trading/risk/analytics.py` - Portfolio aggregation functions
-   - `unity_trading/math/options.py` - Any missing calculations
+   - `src/unity_wheel/risk/analytics.py` - Portfolio aggregation functions
+   - `src/unity_wheel/math/options.py` - Any missing calculations
    - Pattern: Return `CalculationResult(value, confidence)` tuples
 
 3. **Performance Optimization** - Vectorize remaining loops
-   - `unity_trading/strategy/wheel.py` - Strike selection loops
-   - `unity_trading/risk/analytics.py` - Portfolio calculations
+   - `src/unity_wheel/strategy/wheel.py` - Strike selection loops
+   - `src/unity_wheel/risk/analytics.py` - Portfolio calculations
    - Pattern: Replace `for` loops with numpy operations
 
 ### **MEDIUM PRIORITY** (Nice to Have)
@@ -125,10 +125,10 @@ python .codex/minimal_trader.py
 ### Quick Validation
 ```bash
 # After making changes, test them
-python -c "from unity_trading.math.options import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
+python -c "from src.unity_wheel.math.options import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
 
 # Check specific module
-python -c "from unity_trading.risk.analytics import RiskAnalyzer; print('Risk module works')"
+python -c "from src.unity_wheel.risk.analytics import RiskAnalyzer; print('Risk module works')"
 
 # Run targeted test
 pytest tests/test_wheel.py::test_find_optimal_put_strike -v
@@ -139,7 +139,7 @@ pytest tests/test_wheel.py::test_find_optimal_put_strike -v
 # When ready to commit your optimizations
 ./.codex/sync_to_src.sh
 
-# This copies your changes from unity_trading/ back to src/
+# This copies your changes from src/unity_wheel/ back to src/
 # Then commit as normal
 git add src/
 git commit -m "Codex optimizations: [describe your changes]"
@@ -158,7 +158,7 @@ echo $PYTHONPATH
 export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 
 # Test import
-python -c "from unity_trading import __version__; print(__version__)"
+python -c "from src.unity_wheel import __version__; print(__version__)"
 ```
 
 ### If Math Functions Fail
@@ -167,7 +167,7 @@ python -c "from unity_trading import __version__; print(__version__)"
 export USE_PURE_PYTHON=true
 
 # Test basic calculation
-python -c "from unity_trading.math.options import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
+python -c "from src.unity_wheel.math.options import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
 ```
 
 ### If Data Access Fails
@@ -177,7 +177,7 @@ export USE_MOCK_DATA=true
 export DATABENTO_SKIP_VALIDATION=true
 
 # Test advisor
-python -c "from unity_trading.api.advisor import WheelAdvisor; print('Mock data mode')"
+python -c "from src.unity_wheel.api.advisor import WheelAdvisor; print('Mock data mode')"
 ```
 
 ---
@@ -187,7 +187,7 @@ python -c "from unity_trading.api.advisor import WheelAdvisor; print('Mock data 
 ### You'll Know Setup is Complete When:
 - ✅ `python .codex/check_environment.py` shows all green checkmarks
 - ✅ `python .codex/test_config.py` reports "CONFIGURATION PERFECT"
-- ✅ `python -c "from unity_trading import __version__; print(__version__)"` works
+- ✅ `python -c "from src.unity_wheel import __version__; print(__version__)"` works
 - ✅ Basic math calculation succeeds: `bs(100, 100, 1, 0.05, 0.2, 'call')`
 
 ### You'll Know Optimizations Are Working When:
@@ -214,7 +214,7 @@ You now have:
 
 **Start optimizing now!** 🚀
 
-Focus on **unity_trading/** directory - you have full write access to all 123 Python files. Make the Unity Wheel Trading Bot even better!
+Focus on **src/unity_wheel/** directory - you have full write access to all 123 Python files. Make the Unity Wheel Trading Bot even better!
 
 ---
 

--- a/.codex/CODEX_GUIDE.md
+++ b/.codex/CODEX_GUIDE.md
@@ -1,17 +1,17 @@
 # Codex Optimization Guide
 
 ## 🎯 **IMMEDIATE CONTEXT**
-You have full access to the Unity Wheel Trading Bot codebase through symbolic links in the restricted directories. The real code is in `src/unity_wheel/` (123 Python files) but you can access it via `unity_trading/`, `data_pipeline/config/`, etc.
+You have full access to the Unity Wheel Trading Bot codebase through symbolic links in the restricted directories. The real code resides in `src/unity_wheel/` (123 Python files). The older `unity_trading/` path is kept as a symlink for compatibility.
 
 ## 🔥 **CRITICAL SUCCESS PATTERNS**
 
 ### ✅ **What Works for You:**
-1. **File Access**: Use `unity_trading/` instead of `src/unity_wheel/`
+1. **File Access**: Prefer `src/unity_wheel/` for imports. The `unity_trading/` symlink is provided only for legacy support.
 2. **Testing**: Run `pytest tests/test_*.py -v` - all 106+ tests pass
-3. **Type Checking**: `mypy --strict unity_trading data_pipeline app --ignore-missing-imports`
+3. **Type Checking**: `mypy --strict src/unity_wheel data_pipeline app --ignore-missing-imports`
 4. **Quick Validation**: `./scripts/housekeeping.sh --unity-check` (2 seconds)
 5. **Auto-Fix**: `./scripts/housekeeping.sh --fix` resolves file placement issues
-6. Legacy packages `ml_engine`, `risk_engine`, and `strategy_engine` have been removed; use modules under `unity_trading`.
+6. Legacy packages `ml_engine`, `risk_engine`, and `strategy_engine` have been removed; use modules under `src/unity_wheel`.
 
 ### ❌ **What Blocks You:**
 1. **Execution Code**: Never add `execute_trade()`, `place_order()`, `broker.execute()`
@@ -40,8 +40,8 @@ except (ValueError, ConnectionError) as e:
 **Search locations for bare excepts:**
 ```bash
 # Find bare exception handlers
-rg "except\s*:" unity_trading/ data_pipeline/ --type py
-rg "except\s+Exception\s*:" unity_trading/ data_pipeline/ --type py
+rg "except\s*:" src/unity_wheel/ data_pipeline/ --type py
+rg "except\s+Exception\s*:" src/unity_wheel/ data_pipeline/ --type py
 ```
 
 ### **Performance Optimization Patterns**
@@ -79,7 +79,7 @@ max_position = config.risk.position_limits.max_position_size
 
 | Codex Access | Real Location | Purpose |
 |--------------|---------------|---------|
-| `unity_trading/` | `src/unity_wheel/` | Main codebase (123 files) |
+| `unity_trading/` | `src/unity_wheel/` (canonical) | Main codebase (123 files) |
 | `data_pipeline/config/` | `src/config/` | Configuration system |
 | `data_pipeline/patterns/` | `src/patterns/` | Reusable patterns |
 | `tests/` | `tests/` | Test suite (106+ tests) |
@@ -106,7 +106,7 @@ pytest tests/test_performance_benchmarks.py -v
 ### 1. **Replace Bare Exceptions**
 ```bash
 # Find them
-rg "except:" unity_trading/ --type py -A 2 -B 2
+rg "except:" src/unity_wheel/ --type py -A 2 -B 2
 
 # Replace pattern
 except ValueError as e:
@@ -178,8 +178,8 @@ pytest tests/test_wheel.py -v              # Test core functionality
 ./scripts/housekeeping.sh --unity-check
 
 # 2. Find optimization targets
-rg "except:" unity_trading/ --type py
-rg "for.*in.*range" unity_trading/ --type py | grep -v test
+rg "except:" src/unity_wheel/ --type py
+rg "for.*in.*range" src/unity_wheel/ --type py | grep -v test
 
 # 3. Make changes using patterns above
 

--- a/.codex/CONTAINER_README.md
+++ b/.codex/CONTAINER_README.md
@@ -25,7 +25,7 @@ python3 .codex/verify_setup.py
 
 ### Math Module Conflict
 
-This project has a `unity_trading.math` module that conflicts with Python's standard library `math` module. This can prevent pip from working properly.
+This project has a `src.unity_wheel.math` module that conflicts with Python's standard library `math` module. This can prevent pip from working properly.
 
 **The setup scripts handle this automatically by:**
 1. Installing packages BEFORE adding the project to PYTHONPATH

--- a/.codex/CURRENT_STATE.md
+++ b/.codex/CURRENT_STATE.md
@@ -25,28 +25,28 @@
 ### 1. Exception Handling
 ```bash
 # Find remaining bare exceptions (if any)
-rg "except\s*:" unity_trading/ data_pipeline/ --type py
-rg "except\s+Exception\s*:" unity_trading/ data_pipeline/ --type py
+rg "except\s*:" src/unity_wheel/ data_pipeline/ --type py
+rg "except\s+Exception\s*:" src/unity_wheel/ data_pipeline/ --type py
 ```
 
 ### 2. Performance Bottlenecks
 ```bash
 # Find non-vectorized loops that could be optimized
-rg "for.*in.*range" unity_trading/ --type py | grep -v test
-rg "for.*strike.*in" unity_trading/ --type py
+rg "for.*in.*range" src/unity_wheel/ --type py | grep -v test
+rg "for.*strike.*in" src/unity_wheel/ --type py
 ```
 
 ### 3. Missing Confidence Scores
 ```bash
 # Check if any calculation functions still lack confidence scores
-rg "def (calculate_|black_scholes)" unity_trading/ --type py -A 5 | grep -v confidence
+rg "def (calculate_|black_scholes)" src/unity_wheel/ --type py -A 5 | grep -v confidence
 ```
 
 ### 4. Hardcoded Values
 ```bash
 # Check for remaining hardcoded values
-rg "(position_size|num_contracts|contract_count)\s*=\s*[0-9]+" unity_trading/ --type py
-rg "volatility.*[<>].*[0-9]" unity_trading/ --type py
+rg "(position_size|num_contracts|contract_count)\s*=\s*[0-9]+" src/unity_wheel/ --type py
+rg "volatility.*[<>].*[0-9]" src/unity_wheel/ --type py
 ```
 
 ## 📊 **CURRENT METRICS**
@@ -100,7 +100,7 @@ pytest tests/test_wheel.py tests/test_math.py -v
 ./scripts/housekeeping.sh --explain
 
 # Performance test
-python -c "from unity_trading.strategy.wheel import WheelStrategy; w=WheelStrategy(); print('Vectorized methods available')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; w=WheelStrategy(); print('Vectorized methods available')"
 ```
 
 Your focus should be on finding and optimizing any remaining inefficiencies, not re-implementing what's already been done!

--- a/.codex/ENVIRONMENT_SETUP.md
+++ b/.codex/ENVIRONMENT_SETUP.md
@@ -116,8 +116,8 @@ for pkg in optional:
 ### When numpy is not available
 ```python
 # Pure Python math implementations available in:
-# unity_trading/math/options.py - has fallback math
-# unity_trading/utils/position_sizing.py - pure Python calculations
+# src/unity_wheel/math/options.py - has fallback math
+# src/unity_wheel/utils/position_sizing.py - pure Python calculations
 
 # Enable fallback mode
 export USE_PURE_PYTHON=true
@@ -143,13 +143,13 @@ export USE_MEMORY_ONLY=true
 ### Test Basic Functionality
 ```bash
 # Test core imports
-python -c "from unity_trading.math.options import black_scholes_price_validated; print('✅ Math module works')"
+python -c "from src.unity_wheel.math.options import black_scholes_price_validated; print('✅ Math module works')"
 
 # Test strategy module
-python -c "from unity_trading.strategy.wheel import WheelStrategy; print('✅ Strategy module works')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; print('✅ Strategy module works')"
 
 # Test with fallback data
-DATABENTO_SKIP_VALIDATION=true python -c "from unity_trading.api.advisor import WheelAdvisor; print('✅ API module works')"
+DATABENTO_SKIP_VALIDATION=true python -c "from src.unity_wheel.api.advisor import WheelAdvisor; print('✅ API module works')"
 ```
 
 ### Run with Minimal Dependencies
@@ -161,7 +161,7 @@ export DATABENTO_SKIP_VALIDATION=true
 
 # Try a basic recommendation
 python -c "
-from unity_trading.api.advisor_simple import WheelAdvisorSimple
+from src.unity_wheel.api.advisor_simple import WheelAdvisorSimple
 advisor = WheelAdvisorSimple()
 print('✅ Simple advisor works')
 "
@@ -217,7 +217,7 @@ python run.py --portfolio 100000
 ```bash
 # Basic packages only
 export USE_PURE_PYTHON=true
-python -c "from unity_trading.api.advisor_simple import WheelAdvisorSimple; print('Limited mode ready')"
+python -c "from src.unity_wheel.api.advisor_simple import WheelAdvisorSimple; print('Limited mode ready')"
 ```
 
 ### Profile 3: Offline Environment
@@ -226,7 +226,7 @@ python -c "from unity_trading.api.advisor_simple import WheelAdvisorSimple; prin
 export OFFLINE_MODE=true
 export USE_MOCK_DATA=true
 export USE_PURE_PYTHON=true
-python -c "from unity_trading.strategy.wheel import WheelStrategy; print('Offline mode ready')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; print('Offline mode ready')"
 ```
 
 ---
@@ -250,11 +250,11 @@ python .codex/test_config.py
 ### Pre-configured Commands
 ```bash
 # Safe commands that work in any environment
-python -c "from unity_trading.math import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
+python -c "from src.unity_wheel.math import black_scholes_price_validated as bs; print(bs(100, 100, 1, 0.05, 0.2, 'call'))"
 
-python -c "from unity_trading.utils.position_sizing import calculate_position_size; print('Position sizing available')"
+python -c "from src.unity_wheel.utils.position_sizing import calculate_position_size; print('Position sizing available')"
 
-python -c "from unity_trading.strategy.wheel import WheelStrategy; w = WheelStrategy(); print('Strategy available')"
+python -c "from src.unity_wheel.strategy.wheel import WheelStrategy; w = WheelStrategy(); print('Strategy available')"
 ```
 
 ---
@@ -291,7 +291,7 @@ python -c "import sys; print('\\n'.join(sys.path))"
 
 # Add current directory to path
 export PYTHONPATH="${PYTHONPATH}:$(pwd)"
-python -c "from unity_trading import __version__; print(f'Unity Wheel v{__version__}')"
+python -c "from src.unity_wheel import __version__; print(f'Unity Wheel v{__version__}')"
 ```
 
 ---
@@ -305,9 +305,9 @@ import sys
 print(f'Python: {sys.version}')
 
 try:
-    from unity_trading.strategy.wheel import WheelStrategy
-    from unity_trading.math.options import black_scholes_price_validated
-    from unity_trading.utils.position_sizing import calculate_position_size
+    from src.unity_wheel.strategy.wheel import WheelStrategy
+    from src.unity_wheel.math.options import black_scholes_price_validated
+    from src.unity_wheel.utils.position_sizing import calculate_position_size
     print('✅ Unity Wheel Trading Bot is ready!')
 except ImportError as e:
     print(f'❌ Setup incomplete: {e}')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This project uses an automated housekeeping script to enforce file placement and
    ```bash
    ruff format . && black .
    ruff check --fix .
-   mypy --strict unity_trading data_pipeline app --ignore-missing-imports
+   mypy --strict src/unity_wheel data_pipeline app --ignore-missing-imports
    pytest -q
    ```
 4. Commit your changes once all checks pass.
@@ -29,4 +29,4 @@ Refer to `HOUSEKEEPING_GUIDE.md` for full details on the import fix pattern and 
 
 ### Package Structure
 Legacy directories `ml_engine`, `strategy_engine`, and `risk_engine` were removed.
-Use the `unity_trading` package for all imports.
+Use the `src/unity_wheel` package for all imports.


### PR DESCRIPTION
## Summary
- update CONTRIBUTING to reference `src/unity_wheel`
- revise Codex docs to use `src.unity_wheel` path
- clarify that `unity_trading` is a legacy symlink

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6848d4eba1488330ab0f9c9778f1f602